### PR TITLE
Check for whitespace when reading memo and don't throw exception when…

### DIFF
--- a/src/DbfDataReader/DbfMemoDbase4.cs
+++ b/src/DbfDataReader/DbfMemoDbase4.cs
@@ -19,7 +19,7 @@ namespace DbfDataReader
 
         public override string BuildMemo(long startBlock)
         {
-            throw new System.NotImplementedException();
+            return null;
         }
     }
 }

--- a/src/DbfDataReader/DbfValueMemo.cs
+++ b/src/DbfDataReader/DbfValueMemo.cs
@@ -29,7 +29,7 @@ namespace DbfDataReader
                 else
                 {
                     var startBlock = long.Parse(value);
-                    Value = _memo.Get(startBlock);
+                    Value = _memo?.Get(startBlock);
                 }
             }
         }

--- a/src/DbfDataReader/DbfValueMemo.cs
+++ b/src/DbfDataReader/DbfValueMemo.cs
@@ -22,7 +22,7 @@ namespace DbfDataReader
             else
             {
                 var value = new string(binaryReader.ReadChars(Length));
-                if (string.IsNullOrEmpty(value))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     Value = string.Empty;
                 }


### PR DESCRIPTION
There are some usability issues using this package. I added a check for white space when reading memo and no longer throwing an exception in unimplemented memo code.