### PR TITLE
Added DbfDataReaderOptions with ability to skip null binary check

### DIFF
--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -10,13 +10,19 @@ namespace DbfDataReader
         public DbfDataReader(string path)
         {
             DbfTable = new DbfTable(path);
-            DbfRecord = new DbfRecord(DbfTable);
+            DbfRecord = new DbfRecord(DbfTable, new DbfDataReaderOptions());
         }
 
         public DbfDataReader(string path, Encoding encoding)
         {
             DbfTable = new DbfTable(path, encoding);
-            DbfRecord = new DbfRecord(DbfTable);
+            DbfRecord = new DbfRecord(DbfTable, new DbfDataReaderOptions());
+        }
+
+        public DbfDataReader(string path, Encoding encoding, DbfDataReaderOptions options)
+        {
+            DbfTable = new DbfTable(path, encoding);
+            DbfRecord = new DbfRecord(DbfTable, options);
         }
 
         public DbfTable DbfTable { get; private set; }

--- a/src/DbfDataReader/DbfDataReaderOptions.cs
+++ b/src/DbfDataReader/DbfDataReaderOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace DbfDataReader
+{
+    public class DbfDataReaderOptions
+    {
+        public bool SkipNullBinaryCheck { get; set; }
+    }
+}

--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -8,18 +8,22 @@ namespace DbfDataReader
     {
         private const byte EndOfFile = 0x1a;
 
-        public DbfRecord(DbfTable dbfTable)
+        public DbfRecord(DbfTable dbfTable) : this(dbfTable, new DbfDataReaderOptions())
+        {
+        }
+
+        public DbfRecord(DbfTable dbfTable, DbfDataReaderOptions options)
         {
             Values = new List<IDbfValue>();
 
             foreach (var dbfColumn in dbfTable.Columns)
             {
-                var dbfValue = CreateDbfValue(dbfColumn, dbfTable.Memo);
+                var dbfValue = CreateDbfValue(dbfColumn, dbfTable.Memo, options);
                 Values.Add(dbfValue);
             }
         }
 
-        private static IDbfValue CreateDbfValue(DbfColumn dbfColumn, DbfMemo memo)
+        private static IDbfValue CreateDbfValue(DbfColumn dbfColumn, DbfMemo memo, DbfDataReaderOptions options)
         {
             IDbfValue value;
 
@@ -36,13 +40,13 @@ namespace DbfDataReader
                     }
                     break;
                 case DbfColumnType.Signedlong:
-                    value = new DbfValueLong(dbfColumn.Length);
+                    value = new DbfValueLong(dbfColumn.Length, options);
                     break;
                 case DbfColumnType.Float:
                     value = new DbfValueFloat(dbfColumn.Length);
                     break;
                 case DbfColumnType.Currency:
-                    value = new DbfValueCurrency(dbfColumn.Length, dbfColumn.DecimalCount);
+                    value = new DbfValueCurrency(dbfColumn.Length, dbfColumn.DecimalCount, options);
                     break;
                 case DbfColumnType.Date:
                     value = new DbfValueDate(dbfColumn.Length);

--- a/src/DbfDataReader/DbfValueCurrency.cs
+++ b/src/DbfDataReader/DbfValueCurrency.cs
@@ -5,9 +5,16 @@ namespace DbfDataReader
 {
     public class DbfValueCurrency : DbfValue<float?>
     {
-        public DbfValueCurrency(int length, int decimalCount) : base(length)
+        private readonly DbfDataReaderOptions options;
+
+        public DbfValueCurrency(int length, int decimalCount) : this(length, decimalCount, new DbfDataReaderOptions())
+        {
+        }
+
+        public DbfValueCurrency(int length, int decimalCount, DbfDataReaderOptions options) : base(length)
         {
             DecimalCount = decimalCount;
+            this.options = options;
         }
 
         public int DecimalCount { get; set; }
@@ -15,7 +22,7 @@ namespace DbfDataReader
         public override void Read(BinaryReader binaryReader)
         {
             var bytes = binaryReader.ReadBytes(Length);
-            if (bytes[0] == '\0')
+            if (!options.SkipNullBinaryCheck && bytes[0] == '\0')
             {
                 Value = null;
             }

--- a/src/DbfDataReader/DbfValueLong.cs
+++ b/src/DbfDataReader/DbfValueLong.cs
@@ -4,13 +4,20 @@ namespace DbfDataReader
 {
     public class DbfValueLong : DbfValue<long?>
     {
-        public DbfValueLong(int length) : base(length)
+        private readonly DbfDataReaderOptions options;
+
+        public DbfValueLong(int length) : this(length, new DbfDataReaderOptions())
         {
+        }
+
+        public DbfValueLong(int length, DbfDataReaderOptions options) : base(length)
+        {
+            this.options = options;
         }
 
         public override void Read(BinaryReader binaryReader)
         {
-            if (binaryReader.PeekChar() == '\0')
+            if (!options.SkipNullBinaryCheck && binaryReader.PeekChar() == '\0')
             {
                 binaryReader.ReadBytes(4);
                 Value = null;


### PR DESCRIPTION
Added an options class called DbfDataReaderOptions that allows the null binary check to be bypassed when reading DbfValueCurrency and DbfValueLong from DbfColumnType.Currency and DbfColumnType.Signedlong-type columns, respectively. Defaults to false.

Usage:

`using (var reader = new DbfDataReader.DbfDataReader(path, Encoding.GetEncoding(options.Encoding), new DbfDataReader.DbfDataReaderOptions { SkipNullBinaryCheck = true }))`