### PR TITLE
improved fix for #59 / #69

### DIFF
--- a/src/DbfDataReader/DbfColumn.cs
+++ b/src/DbfDataReader/DbfColumn.cs
@@ -23,7 +23,7 @@ namespace DbfDataReader
         private void Read(BinaryReader binaryReader)
         {
             var rawName = binaryReader.ReadString(11, _encoding);
-            Name = rawName.TrimEnd((char) 0);
+            Name = rawName.Split((char)0)[0];
 
             var type = binaryReader.ReadByte();
             ColumnType = (DbfColumnType) type;

--- a/src/DbfDataReader/DbfColumn.cs
+++ b/src/DbfDataReader/DbfColumn.cs
@@ -23,7 +23,12 @@ namespace DbfDataReader
         private void Read(BinaryReader binaryReader)
         {
             var rawName = binaryReader.ReadString(11, _encoding);
-            Name = rawName.Split((char)0)[0];
+            var nullIdx = rawName.IndexOf((char)0);
+            if (nullIdx >= 0)
+            {
+                rawName = rawName.Substring(0, nullIdx);   // trim off everything past & including the first NUL byte
+            }
+			Name = rawName;
 
             var type = binaryReader.ReadByte();
             ColumnType = (DbfColumnType) type;
@@ -34,7 +39,14 @@ namespace DbfDataReader
             Length = binaryReader.ReadByte();
             DecimalCount = binaryReader.ReadByte();
 
-            // skip the reserved bytes
+            // skip the reserved bytes:
+            // - Int16: reserved1
+            // - Byte: workarea_id
+            // - Byte: reserved2
+            // - Byte: reserved3
+            // - Byte: set_fields_flag
+            // - String7: reserved4
+            // - Byte: index_field_flag
             binaryReader.ReadBytes(14);
         }
     }

--- a/src/DbfDataReader/DbfMemoDbase3.cs
+++ b/src/DbfDataReader/DbfMemoDbase3.cs
@@ -34,7 +34,12 @@ namespace DbfDataReader
             } while (!finished);
 
             var value = stringBuilder.ToString();
-            value = value.TrimEnd('\0', ' ');
+            var nullIdx = value.IndexOf((char)0);
+            if (nullIdx >= 0)
+            {
+                value = value.Substring(0, nullIdx);   // trim off everything past & including the first NUL byte
+            }
+            value = value.TrimEnd(' ');
             return value;
         }
     }

--- a/src/DbfDataReader/DbfMemoFoxPro.cs
+++ b/src/DbfDataReader/DbfMemoFoxPro.cs
@@ -41,7 +41,12 @@ namespace DbfDataReader
             if (blockType != 1 || memoLength == 0) return string.Empty;
 
             var value = BinaryReader.ReadString(memoLength, CurrentEncoding);
-            value = value.TrimEnd('\0', ' ');
+            var nullIdx = value.IndexOf((char)0);
+            if (nullIdx >= 0)
+            {
+                value = value.Substring(0, nullIdx);   // trim off everything past & including the first NUL byte
+            }
+            value = value.TrimEnd(' ');
             return value;
         }
     }

--- a/src/DbfDataReader/DbfValueDate.cs
+++ b/src/DbfDataReader/DbfValueDate.cs
@@ -13,7 +13,11 @@ namespace DbfDataReader
         public override void Read(BinaryReader binaryReader)
         {
             var value = new string(binaryReader.ReadChars(8));
-            value = value.TrimEnd((char) 0);
+            var nullIdx = value.IndexOf((char)0);
+            if (nullIdx >= 0)
+            {
+                value = value.Substring(0, nullIdx);   // trim off everything past & including the first NUL byte
+            }
 
             if (string.IsNullOrWhiteSpace(value))
                 Value = null;


### PR DESCRIPTION
See also comment at https://github.com/yellowfeather/DbfDataReader/issues/59#issuecomment-713048884-permalink

This is an augmented version of the #69 pull req: addresses NULs everywhere and faster than with using string.Split() (when a field contains more than one NUL byte as in the example shown in that comment).