### PR TITLE
Fix scenario where tostring on numeric value shows wrong answer

### DIFF
--- a/src/DbfDataReader/DbfValueCurrency.cs
+++ b/src/DbfDataReader/DbfValueCurrency.cs
@@ -21,7 +21,7 @@ namespace DbfDataReader
         public override string ToString()
         {
             var format = DecimalCount != 0
-                ? $"0.{new string('0', DecimalCount)}"
+                ? $"F{DecimalCount}"
                 : null;
 
             return Value?.ToString(format, NumberFormatInfo.CurrentInfo) ?? string.Empty;

--- a/src/DbfDataReader/DbfValueDecimal.cs
+++ b/src/DbfDataReader/DbfValueDecimal.cs
@@ -38,7 +38,7 @@ namespace DbfDataReader
         public override string ToString()
         {
             var format = DecimalCount != 0
-                ? $"0.{new string('0', DecimalCount)}"
+                ? $"F{DecimalCount}"
                 : null;
 
             return Value?.ToString(format, NumberFormatInfo.CurrentInfo) ?? string.Empty;

--- a/src/DbfDataReader/DbfValueDouble.cs
+++ b/src/DbfDataReader/DbfValueDouble.cs
@@ -20,7 +20,7 @@ namespace DbfDataReader
         public override string ToString()
         {
             var format = DecimalCount != 0
-                ? $"0.{new string('0', DecimalCount)}"
+                ? $"F{DecimalCount}"
                 : null;
 
             return Value?.ToString(format, NumberFormatInfo.CurrentInfo) ?? string.Empty;

--- a/src/DbfDataReader/DbfValueFloat.cs
+++ b/src/DbfDataReader/DbfValueFloat.cs
@@ -43,7 +43,7 @@ namespace DbfDataReader
         public override string ToString()
         {
             var format = DecimalCount != 0
-                ? $"0.{new string('0', DecimalCount)}"
+                ? $"F{DecimalCount}"
                 : null;
 
             return Value?.ToString(format, NumberFormatInfo.CurrentInfo) ?? string.Empty;


### PR DESCRIPTION
 if you have a float value with say 2 decimal places and a value of 3.367 when calling ToString would show 3.40 which is wrong.

Updated the ToString overloads to $"F{DecimalCount}", which will show decimal places to the accuracy of the decimal count.

I have run the testsuite and they all continue to pass.