### PR TITLE
Added a configuration object for the DbfRecord class

### DIFF
--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -14,8 +14,18 @@ namespace DbfDataReader
         private readonly int _recordLength;
         private readonly byte[] _buffer;
 
-        public DbfRecord(DbfTable dbfTable)
+        private readonly DbfRecordConfiguration Config;
+
+        public DbfRecord(DbfTable dbfTable, DbfRecordConfiguration config = null)
         {
+            if (config == null)
+            {
+                this.Config = DbfRecordConfiguration.GetDefault();
+            }
+            else {
+                this.Config = config;
+            }
+
             _encoding = dbfTable.CurrentEncoding;
             _recordLength = dbfTable.Header.RecordLength;
             _buffer = new byte[_recordLength];
@@ -55,7 +65,13 @@ namespace DbfDataReader
                     value = new DbfValueLong(dbfColumn.Start, dbfColumn.Length);
                     break;
                 case DbfColumnType.Float:
-                    value = new DbfValueFloat(dbfColumn.Start, dbfColumn.Length, dbfColumn.DecimalCount);
+                    if (this.Config.ReadFloatsAsDecimals)
+                    {
+                        value = new DbfValueDecimal(dbfColumn.Start, dbfColumn.Length, dbfColumn.DecimalCount);
+                    }
+                    else {
+                        value = new DbfValueFloat(dbfColumn.Start, dbfColumn.Length, dbfColumn.DecimalCount);
+                    }
                     break;
                 case DbfColumnType.Currency:
                     value = new DbfValueCurrency(dbfColumn.Start, dbfColumn.Length, dbfColumn.DecimalCount);

--- a/src/DbfDataReader/DbfRecordConfiguration.cs
+++ b/src/DbfDataReader/DbfRecordConfiguration.cs
@@ -1,0 +1,25 @@
+﻿namespace DbfDataReader
+{
+    /// <summary>
+    ///     Class <c>DbfRecordConfiguration</c> provides a configuration for the <c>DbfRecord</c> class
+    /// </summary>
+    public class DbfRecordConfiguration
+    {
+        /// <summary>
+        ///     Configuation that denotes floats from the database should be read as <c>decimal</c> in C#. 
+        ///     This is to mitigate precision issues where a number in the database is labeled as a float, but is greater than the size of a float in C#
+        /// </summary>
+        public bool ReadFloatsAsDecimals { get; set; }
+
+        /// <summary>
+        ///     Provides a default configuration
+        /// </summary>
+        /// <returns>A <c>DbfRecordConfigration</c> object containing the default configuration</returns>
+        public static DbfRecordConfiguration GetDefault()
+        {
+            return new DbfRecordConfiguration { 
+                ReadFloatsAsDecimals = false 
+            };
+        }
+    }
+}


### PR DESCRIPTION
It is possible to run into issues where a value in a dbf file is has a type of `Float`, but is larger than a `float` in C#.

This would cause precision issues when the value is passed into the `float.TryParse` method.

See the below example:
```csharp
var numberAsString = "123456.78";
float.TryParse(numberAsString, out var numberAsFloat); // numberAsFloat will be 123456.781 here

// Using ToString will round it back to 123456.78
Console.WriteLine(numberAsFloat.ToString());
```

It's worth noting that calling `ToString` on the float with no parameters would round to the nearest hundredth and coincidentally show the value as what it is supposed to be.

In order to mitigate this, a configuration class was created that can be passed into the `DbfRecord` class. This configuration currently contains one property (`ReadFloatsAsDecimals`) that will tell the `CreateDbfValue` method to use the `DbfValueDecimal` class for floats instead of the `DbfValueFloat` class.

The configuration that gets provided is an optional parameter on the `DbfRecord` class and provides a default configuration that matches the current expected behavior.