### PR TITLE
Fixed DbfValueDateTime null values checking

### DIFF
--- a/src/DbfDataReader/DbfValueDateTime.cs
+++ b/src/DbfDataReader/DbfValueDateTime.cs
@@ -11,7 +11,15 @@ namespace DbfDataReader
 
         public override void Read(ReadOnlySpan<byte> bytes)
         {
-            if (bytes[0] == '\0')
+            int i;
+            for (i = 0; i < bytes.Length; i++)
+            {
+                if (bytes[0] != '\0')
+                {
+                    break;
+                }
+            }
+            if (i == bytes.Length)
             {
                 Value = null;
             }


### PR DESCRIPTION
I found an issue with some dates being considered null when they where not.
One such example is `2020-10-13 00:00:00` which has a byte equivalent of `{ 0, 134, 37, 0 }`.