### PR TITLE
Support for "W"-type columns

### DIFF
--- a/src/DbfDataReader/DbfColumn.cs
+++ b/src/DbfDataReader/DbfColumn.cs
@@ -42,6 +42,11 @@ namespace DbfDataReader
                 Length =  BitConverter.ToInt16(bytes.Slice(16, 2));
                 DecimalCount = 0;
             }
+            else if (ColumnType == DbfColumnType.WideCharacter)
+            {
+                Length =  BitConverter.ToInt16(bytes.Slice(16, 2));
+                DecimalCount = 0;
+            }
             else
             {
                 Length = length;
@@ -85,6 +90,7 @@ namespace DbfDataReader
                     return typeof(double);
                 case DbfColumnType.General:
                 case DbfColumnType.Character:
+                case DbfColumnType.WideCharacter:
                     return typeof(string);
                 default:
                     return typeof(object);

--- a/src/DbfDataReader/DbfColumnType.cs
+++ b/src/DbfDataReader/DbfColumnType.cs
@@ -12,6 +12,7 @@
         Memo = 'M',
         Double = 'B',
         General = 'G',
-        Character = 'C'
+        Character = 'C',
+        WideCharacter = 'W'
     }
 }

--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -79,6 +79,9 @@ namespace DbfDataReader
                 case DbfColumnType.Character:
                     value = new DbfValueString(dbfColumn.Start, dbfColumn.Length, _encoding);
                     break;
+                case DbfColumnType.WideCharacter:
+                    value = new DbfValueWideString(dbfColumn.Start, dbfColumn.Length);
+                    break;
                 default:
                     value = new DbfValueNull(dbfColumn.Start, dbfColumn.Length);
                     break;

--- a/src/DbfDataReader/DbfValueMemo.cs
+++ b/src/DbfDataReader/DbfValueMemo.cs
@@ -18,7 +18,7 @@ namespace DbfDataReader
             if (Length == 4)
             {
                 var startBlock = BitConverter.ToUInt32(bytes);
-                Value = _memo.Get(startBlock);
+                Value = _memo?.Get(startBlock);
             }
             else
             {

--- a/src/DbfDataReader/DbfValueWideString.cs
+++ b/src/DbfDataReader/DbfValueWideString.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text;
+
+namespace DbfDataReader
+{
+    public class DbfValueWideString : DbfValue<string>
+    {
+        private const char NullChar = '\0';
+
+        public DbfValueWideString(int start, int length) : base(start, length)
+        {
+        }
+        
+        public override void Read(ReadOnlySpan<byte> bytes)
+        {
+            if (bytes[0] == NullChar)
+            {
+                Value = null;
+                return;
+            }
+
+            var value = Encoding.Unicode.GetString(bytes);
+            Value = value.Trim(NullChar, ' ');
+        }
+    }
+}


### PR DESCRIPTION
Because I needed it for a project, I extended the reader to support Unicode columns (type "W")
If I hadn't done this, the reader would just return `null` for all Unicode columns.

I also took the liberty of fixing a bug which causes a `NullReferenceException` when you don't pass a memo stream. A null check was already in place for one branch, but not for cases when the memo length equals 4.