### PR TITLE
Update DbfValueMemo.cs to use `TryParse` rather than `Parse`.

### DIFF
--- a/src/DbfDataReader/DbfValueMemo.cs
+++ b/src/DbfDataReader/DbfValueMemo.cs
@@ -28,10 +28,13 @@ namespace DbfDataReader
                 {
                     Value = string.Empty;
                 }
+                else if (long.TryParse(value, out long startBlock))
+                {
+                    Value = _memo?.Get(startBlock);
+                }
                 else
                 {
-                    var startBlock = long.Parse(value);
-                    Value = _memo?.Get(startBlock);
+                    Value = string.Empty;
                 }
             }
         }


### PR DESCRIPTION
This handles an error case where a null character '\0' is the byte content and during parsing into the startBlock a FormatException is thrown.