### PR TITLE
Make DbfDataReader.GetOrdinal resolve names like IDataRecord.GetOrdinal

### DIFF
--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -211,8 +211,14 @@ namespace DbfDataReader
                 if (dbfColumn.ColumnName == name) return ordinal;
                 ordinal++;
             }
+            ordinal = 0; 
+            foreach (var dbfColumn in DbfTable.Columns)
+            {
+                if (String.Equals(dbfColumn.ColumnName,name,StringComparison.OrdinalIgnoreCase)) return ordinal;
+                ordinal++;
+            }
 
-            return -1;
+            throw new IndexOutOfRangeException();
         }
 
         public override string GetName(int ordinal)

--- a/test/DbfDataReader.Tests/DbfDataReaderTests.cs
+++ b/test/DbfDataReader.Tests/DbfDataReaderTests.cs
@@ -13,6 +13,22 @@ namespace DbfDataReader.Tests
         private const string FixtureSummaryPath = "../../../../fixtures/dbase_03_summary.txt";
 
         [Fact]
+        public void Should_resolve_names_to_ordinals()
+        {
+            // Test if GetOrdinal resolves names according to IDataRecord.GetOrdinal()
+            // see https://learn.microsoft.com/en-us/dotnet/api/system.data.idatarecord.getordinal?view=net-7.0#system-data-idatarecord-getordinal(system-string)
+            using (var dbfDataReader = new DbfDataReader(FixturePath))
+            {
+                dbfDataReader.GetOrdinal("Point_ID").ShouldBe(0);
+                dbfDataReader.GetOrdinal("POINT_ID").ShouldBe(0);
+                dbfDataReader.GetOrdinal("point_id").ShouldBe(0);
+                dbfDataReader.GetOrdinal("Std_Dev").ShouldBe(27);
+                dbfDataReader.GetOrdinal("STD_DEV").ShouldBe(27);
+                dbfDataReader.GetOrdinal("std_dev").ShouldBe(27);
+                Assert.Throws<IndexOutOfRangeException>(() => dbfDataReader.GetOrdinal("NO_SUCH_FIELD"));
+            }
+        }
+        [Fact]
         public void Should_have_valid_first_row_values()
         {
             using (var dbfDataReader = new DbfDataReader(FixturePath))


### PR DESCRIPTION
`GetOrdinal` is supposed to perform a case-sensitive lookup first and if that fails it should try a case-insensitve search. If that also fails, then an `IndexOutOfRangeException` should be thrown.

See https://learn.microsoft.com/en-us/dotnet/api/system.data.idatarecord.getordinal?view=net-7.0 for reference. 

Changes to `GetOrdinal` + test case added. 
