### PR TITLE
Move subtract into AddDays

### DIFF
--- a/src/DbfDataReader/DbfValueDateTime.cs
+++ b/src/DbfDataReader/DbfValueDateTime.cs
@@ -19,8 +19,7 @@ namespace DbfDataReader
             {
                 var datePart = BitConverter.ToInt32(bytes);
                 var timePart = BitConverter.ToInt32(bytes[4..]);
-                Value = new DateTime(1, 1, 1).AddDays(datePart).Subtract(TimeSpan.FromDays(1721426))
-                    .AddMilliseconds(timePart);
+                Value = new DateTime(1, 1, 1).AddDays(datePart-1721426).AddMilliseconds(timePart);
             }
         }
     }


### PR DESCRIPTION
Dates greater than 5286-11-22 will cause an OutOfRange exception.
Moving the subtraction into the AddDays so large dates don't cause the exception