### PR TITLE
Pass ReadFloatsAsDecimals option through DbfDataReader constructors

### DIFF
--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -20,21 +20,21 @@ namespace DbfDataReader
         public DbfDataReader(string path, DbfDataReaderOptions options)
         {
             _options = options;
-            DbfTable = new DbfTable(path, options.Encoding, options.StringTrimming);
+            DbfTable = new DbfTable(path, options.Encoding, options.StringTrimming, options.ReadFloatsAsDecimals);
             DbfRecord = new DbfRecord(DbfTable);
         }
 
         public DbfDataReader(Stream stream, DbfDataReaderOptions options)
         {
             _options = options;
-            DbfTable = new DbfTable(stream, options.Encoding, options.StringTrimming);
+            DbfTable = new DbfTable(stream, options.Encoding, options.StringTrimming, options.ReadFloatsAsDecimals);
             DbfRecord = new DbfRecord(DbfTable);
         }
 
         public DbfDataReader(Stream stream, Stream memoStream, DbfDataReaderOptions options)
         {
             _options = options;
-            DbfTable = new DbfTable(stream, memoStream, options.Encoding, options.StringTrimming);
+            DbfTable = new DbfTable(stream, memoStream, options.Encoding, options.StringTrimming, options.ReadFloatsAsDecimals);
             DbfRecord = new DbfRecord(DbfTable);
         }
 

--- a/test/DbfDataReader.Tests/ReadFloatsAsDecimalsTests.cs
+++ b/test/DbfDataReader.Tests/ReadFloatsAsDecimalsTests.cs
@@ -73,4 +73,13 @@ public class ReadFloatsAsDecimalsTests : DbaseTests
         var dbfValue = dbfRecord.Values[10];
         dbfValue.GetValue().ShouldBeOfType<float>();
     }
+
+    [Fact]
+    public void Should_read_floats_as_decimals_when_using_dbf_data_reader_with_options()
+    {
+        using var dbfDataReader = new DbfDataReader(Dbase31FixturePath, Options);
+
+        dbfDataReader.Read().ShouldBeTrue();
+        dbfDataReader.GetValue(10).ShouldBeOfType<decimal>();
+    }
 }


### PR DESCRIPTION
## Summary
- `DbfDataReader`'s constructors built the underlying `DbfTable` with only `options.Encoding` and `options.StringTrimming`, dropping `options.ReadFloatsAsDecimals`. The option was silently ignored when reading through `DbfDataReader` (and therefore also through `DbfDbConnection`/`DbfDbCommand`, which faithfully set it from the connection string) — it only worked when constructing `DbfTable` directly with the 4-arg constructor.
- All three constructors now forward `options.ReadFloatsAsDecimals` to `DbfTable`.

## Test plan
- New regression test `Should_read_floats_as_decimals_when_using_dbf_data_reader_with_options` reads the `dbase_31` fixture through `DbfDataReader` with the option set and asserts the float column materialises as `decimal` (failed before this fix).
- Full suite passes: 100 passed, 1 skipped (pre-existing WIP skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)