### PR TITLE
Read currency values as decimal instead of float

### DIFF
--- a/src/DbfDataReader/DbfValueCurrency.cs
+++ b/src/DbfDataReader/DbfValueCurrency.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace DbfDataReader
 {
-    public class DbfValueCurrency : DbfValue<float?>
+    public class DbfValueCurrency : DbfValue<decimal?>
     {
         public DbfValueCurrency(int start, int length, int decimalCount) : base(start, length)
         {
@@ -14,8 +14,9 @@ namespace DbfDataReader
 
         public override void Read(ReadOnlySpan<byte> bytes)
         {
+            // currency is stored as a 64-bit integer scaled by 10,000
             var value = BitConverter.ToInt64(bytes);
-            Value = value / 10000.0f;
+            Value = value / 10000m;
         }
 
         public override string ToString()

--- a/test/DbfDataReader.Tests/FoxproCurrencyTests.cs
+++ b/test/DbfDataReader.Tests/FoxproCurrencyTests.cs
@@ -48,6 +48,17 @@ namespace DbfDataReader.Tests
         {
             ValidateRowValues("../../../../fixtures/foxpro_currency_01.csv");
         }
+
+        [Fact]
+        public void Should_read_currency_values_as_decimal()
+        {
+            using var dbfDataReader = new DbfDataReader(FoxproCurrency01FixturePath);
+
+            dbfDataReader.Read().ShouldBeTrue();
+            dbfDataReader.GetValue(0).ShouldBeOfType<decimal>();
+            dbfDataReader.GetDecimal(0).ShouldBe(20m);
+            dbfDataReader.GetDecimal(1).ShouldBe(-20m);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- `DbfValueCurrency` was backed by `float?` (`value / 10000.0f`) while `DbfColumn.GetDataType` advertises `typeof(decimal)` for `'Y'` columns. Consequences: `GetDecimal()` threw `InvalidCastException` on currency columns (boxed `float` can't unbox to `decimal`), and large currency amounts lost precision to float's ~7 significant digits.
- Currency is stored on disk as a 64-bit integer scaled by 10,000, so `value / 10000m` is always exact. The value type now matches the advertised schema.
- `ToString()` output is unchanged — decimal division produces minimal scale (`"20"`, not `"20.0000"`), so the existing it-IT culture CSV fixture test passes as-is.

## Breaking change
Code that called `GetFloat()`/`GetValue<float>()` on currency columns must switch to `GetDecimal()`/`GetValue<decimal>()`, matching what the column schema already declared.

## Test plan
- New regression test `Should_read_currency_values_as_decimal` reads the `foxpro_currency_01` fixture through `DbfDataReader` and asserts `GetDecimal` returns `20m`/`-20m` (threw `InvalidCastException` before this fix).
- Full suite passes: 100 passed, 1 skipped (pre-existing WIP skip), including the existing currency row-values CSV validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)