### PR TITLE
Handle partial stream reads when reading header and columns on netstandard2.1

### DIFF
--- a/src/DbfDataReader/DbfHeader.cs
+++ b/src/DbfDataReader/DbfHeader.cs
@@ -10,11 +10,7 @@ namespace DbfDataReader
         public DbfHeader(Stream stream)
         {
             var buffer = new byte[DbfHeaderSize];
-#if NETSTANDARD2_1
-            stream.Read(buffer, 0, DbfHeaderSize);
-#else
             stream.ReadExactly(buffer, 0, DbfHeaderSize);
-#endif
             var span = new ReadOnlySpan<byte>(buffer);
             Read(span);
         }

--- a/src/DbfDataReader/DbfTable.cs
+++ b/src/DbfDataReader/DbfTable.cs
@@ -149,11 +149,7 @@ namespace DbfDataReader
         {
             var count = Header.HeaderLength - DbfHeader.DbfHeaderSize;
             var buffer = new byte[count];
-#if NETSTANDARD2_1
-            stream.Read(buffer, 0, count);
-#else
             stream.ReadExactly(buffer, 0, count);
-#endif
             var span = new ReadOnlySpan<byte>(buffer);
 
             var columns = new List<DbfColumn>();

--- a/src/DbfDataReader/StreamExtensions.cs
+++ b/src/DbfDataReader/StreamExtensions.cs
@@ -1,0 +1,21 @@
+#if NETSTANDARD2_1
+using System.IO;
+
+namespace DbfDataReader
+{
+    internal static class StreamExtensions
+    {
+        public static void ReadExactly(this Stream stream, byte[] buffer, int offset, int count)
+        {
+            while (count > 0)
+            {
+                var read = stream.Read(buffer, offset, count);
+                if (read == 0) throw new EndOfStreamException();
+
+                offset += read;
+                count -= read;
+            }
+        }
+    }
+}
+#endif

--- a/test/DbfDataReader.Tests/PartialReadStreamTests.cs
+++ b/test/DbfDataReader.Tests/PartialReadStreamTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests
+{
+    [Collection("dbase_03")]
+    public class PartialReadStreamTests
+    {
+        [Fact]
+        public void Should_read_from_a_stream_that_returns_partial_reads()
+        {
+            const string fixturePath = "../../../../fixtures/dbase_03.dbf";
+
+            using var fileStream = File.OpenRead(fixturePath);
+            using var dbfTable = new DbfTable(new OneBytePerReadStream(fileStream));
+
+            dbfTable.Columns.Count.ShouldBe(31);
+
+            var dbfRecord = new DbfRecord(dbfTable);
+            var count = 0;
+            while (dbfTable.Read(dbfRecord)) count++;
+
+            count.ShouldBe(14);
+        }
+
+        private sealed class OneBytePerReadStream : Stream
+        {
+            private readonly Stream _inner;
+
+            public OneBytePerReadStream(Stream inner)
+            {
+                _inner = inner;
+            }
+
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => _inner.CanSeek;
+            public override bool CanWrite => false;
+            public override long Length => _inner.Length;
+
+            public override long Position
+            {
+                get => _inner.Position;
+                set => _inner.Position = value;
+            }
+
+            public override void Flush() => _inner.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return _inner.Read(buffer, offset, Math.Min(1, count));
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- On netstandard2.1, `DbfHeader` and `DbfTable.ReadColumns` read into their buffers with a single `Stream.Read` call and ignored the return value. `Stream.Read` is allowed to return fewer bytes than requested (network streams, decompression streams, etc.), so a short read would silently parse a half-filled buffer into garbage header/column values. (`DbfRecord.Read` already looped correctly; only the header/column paths were affected.)
- Adds an internal `ReadExactly(byte[], int, int)` extension compiled only for netstandard2.1 that loops until the buffer is filled and throws `EndOfStreamException` on truncation — the same contract as the BCL `Stream.ReadExactly` instance method that net10.0 already uses.
- Because the extension mirrors the BCL signature, both `#if NETSTANDARD2_1` blocks disappear: the identical `stream.ReadExactly(buffer, 0, count)` call resolves to the BCL method on net10.0 and the extension on netstandard2.1. Truncated files now fail loudly and consistently on both TFMs.

## Test plan
- New `PartialReadStreamTests` reads the `dbase_03` fixture through a wrapper stream that returns at most 1 byte per `Read` call and asserts all 31 columns and 14 records parse correctly under maximally-fragmented reads.
- Note the test project targets net10.0 only, so the netstandard2.1 extension path is verified by compilation (the library builds both TFMs); the test guards the record-read loop and the net10.0 path at runtime.
- Full suite passes: 100 passed, 1 skipped (pre-existing WIP skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)