### PR TITLE
Add leaveOpen option for caller-supplied streams

### DIFF
--- a/src/DbfDataReader/DbfTable.cs
+++ b/src/DbfDataReader/DbfTable.cs
@@ -9,6 +9,8 @@ namespace DbfDataReader
     {
         private const byte Terminator = 0x0d;
 
+        private readonly bool _leaveOpen;
+
         public DbfTable(string path, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false)
         {
             if (!File.Exists(path)) throw new FileNotFoundException();
@@ -26,17 +28,18 @@ namespace DbfDataReader
             if (!string.IsNullOrEmpty(memoPath)) Memo = CreateMemo(memoPath);
         }
 
-        public DbfTable(Stream stream, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false)
-            : this(stream, null, encoding, stringTrimming, readFloatsAsDecimals)
+        public DbfTable(Stream stream, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false, bool leaveOpen = false)
+            : this(stream, null, encoding, stringTrimming, readFloatsAsDecimals, leaveOpen)
         {
         }
 
-        public DbfTable(Stream stream, Stream memoStream, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false)
+        public DbfTable(Stream stream, Stream memoStream, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false, bool leaveOpen = false)
         {
             Path = string.Empty;
             CurrentEncoding = encoding;
             StringTrimming = stringTrimming;
             ReadFloatsAsDecimals = readFloatsAsDecimals;
+            _leaveOpen = leaveOpen;
             Stream = stream;
 
             Init();
@@ -80,7 +83,7 @@ namespace DbfDataReader
             try
             {
                 if (!disposing) return;
-                Stream?.Dispose();
+                if (!_leaveOpen) Stream?.Dispose();
                 Memo?.Dispose();
             }
             finally

--- a/test/DbfDataReader.Tests/DbfTableTests.cs
+++ b/test/DbfDataReader.Tests/DbfTableTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.IO;
+using System.Text;
 using Shouldly;
 using Xunit;
 
@@ -33,6 +34,32 @@ namespace DbfDataReader.Tests
             dbfTable.Dispose();
 
             dbfTable.Memo.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_dispose_caller_supplied_stream_by_default()
+        {
+            const string fixturePath = "../../../../fixtures/dbase_03.dbf";
+
+            var stream = File.OpenRead(fixturePath);
+            var dbfTable = new DbfTable(stream);
+
+            dbfTable.Dispose();
+
+            stream.CanRead.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_leave_caller_supplied_stream_open_when_leave_open_is_set()
+        {
+            const string fixturePath = "../../../../fixtures/dbase_03.dbf";
+
+            using var stream = File.OpenRead(fixturePath);
+            var dbfTable = new DbfTable(stream, leaveOpen: true);
+
+            dbfTable.Dispose();
+
+            stream.CanRead.ShouldBeTrue();
         }
     }
 }


### PR DESCRIPTION
## Summary
- `DbfTable.Dispose` disposed the data stream unconditionally, including streams supplied by the caller via the `DbfTable(Stream, ...)` constructors — so a caller-owned stream (e.g. a `MemoryStream` being reused, or a stream whose lifetime is managed elsewhere) was closed out from under its owner.
- Both stream constructors now accept `bool leaveOpen = false`. When set, disposing the table skips disposing the data stream. The default preserves existing behaviour exactly.
- Caller-supplied *memo* streams were already effectively left open (the memo `BinaryReader` wraps them with `leaveOpen: true`), so this brings the data stream in line with an opt-in.

## Compatibility note
This adds a trailing optional parameter to the two stream constructors: fully source-compatible, but technically a binary-compat change (assemblies compiled against the old signature need a recompile), so it fits a minor version bump. A follow-up could surface `LeaveOpen` on `DbfDataReaderOptions` for the reader-over-stream case.

## Test plan
- New tests: `Should_dispose_caller_supplied_stream_by_default` (documents existing default) and `Should_leave_caller_supplied_stream_open_when_leave_open_is_set`.
- Full suite passes: 101 passed, 1 skipped (pre-existing WIP skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)