### PR TITLE
Add Seek and RecordIndex for random record access

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ using (var dbfDataReader = new DbfDataReader(dbfPath, options))
 }
 ```
 
+Records can be accessed randomly by zero-based index using `Seek`, available on both `DbfTable` and `DbfDataReader`. The index of the record most recently read is available as `RecordIndex`:
+
+```csharp
+var dbfPath = "path/file.dbf";
+using (var dbfDataReader = new DbfDataReader(dbfPath))
+{
+    dbfDataReader.Seek(41); // position at the 42nd record
+
+    if (dbfDataReader.Read())
+    {
+        var recordIndex = dbfDataReader.RecordIndex; // 41
+        var valueCol1 = dbfDataReader.GetString(0);
+    }
+}
+```
+
 There is also an implementation of DbConnection so you can query a folder of files e.g.
 
 ```csharp

--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -163,6 +163,13 @@ namespace DbfDataReader
             return result;
         }
 
+        public void Seek(int recordIndex)
+        {
+            DbfTable.Seek(recordIndex);
+        }
+
+        public int RecordIndex => DbfRecord.RecordIndex;
+
         public override int Depth => throw new NotImplementedException();
 
         public override bool IsClosed => DbfTable.IsClosed;

--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -14,6 +14,7 @@ namespace DbfDataReader
         private readonly StringTrimmingOption _stringTrimming;
         private readonly bool _readFloatsAsDecimals;
         private readonly int _recordLength;
+        private readonly long _dataOffset;
         private readonly byte[] _buffer;
 
         public DbfRecord(DbfTable dbfTable)
@@ -22,6 +23,7 @@ namespace DbfDataReader
             _stringTrimming = dbfTable.StringTrimming;
             _readFloatsAsDecimals = dbfTable.ReadFloatsAsDecimals;
             _recordLength = dbfTable.Header.RecordLength;
+            _dataOffset = dbfTable.DataOffset;
             _buffer = new byte[_recordLength];
 
             Values = new List<IDbfValue>();
@@ -34,6 +36,8 @@ namespace DbfDataReader
         }
 
         public bool IsDeleted { get; private set; }
+
+        public int RecordIndex { get; private set; } = -1;
 
         public IList<IDbfValue> Values { get; set; }
 
@@ -102,17 +106,18 @@ namespace DbfDataReader
 
         public bool Read(Stream stream)
         {
-            if (stream.Position == stream.Length) return false;
+            var position = stream.Position;
+            if (position == stream.Length) return false;
 
             try
             {
                 var read = stream.Read(_buffer, 0, _recordLength);
-                if (read <= 0) 
+                if (read <= 0)
                     return false;
                 while (read < _recordLength)
                 {
                     var r = stream.Read(_buffer, read, _recordLength - read);
-                    if (r == 0) 
+                    if (r == 0)
                         return false;
                     read += r;
                 }
@@ -122,6 +127,7 @@ namespace DbfDataReader
                 if (value == EndOfFile) return false;
 
                 IsDeleted = value == 0x2A;
+                RecordIndex = (int) ((position - _dataOffset) / _recordLength);
 
                 foreach (var dbfValue in Values)
                 {

--- a/src/DbfDataReader/DbfTable.cs
+++ b/src/DbfDataReader/DbfTable.cs
@@ -11,6 +11,10 @@ namespace DbfDataReader
 
         private readonly bool _leaveOpen;
 
+        // position of the start of the DBF data within the stream, to support
+        // streams where the DBF content does not begin at offset zero
+        private readonly long _startOffset;
+
         public DbfTable(string path, Encoding encoding = null, StringTrimmingOption stringTrimming = StringTrimmingOption.Trim, bool readFloatsAsDecimals = false)
         {
             if (!File.Exists(path)) throw new FileNotFoundException();
@@ -41,6 +45,7 @@ namespace DbfDataReader
             ReadFloatsAsDecimals = readFloatsAsDecimals;
             _leaveOpen = leaveOpen;
             Stream = stream;
+            _startOffset = stream.CanSeek ? stream.Position : 0;
 
             Init();
 
@@ -72,6 +77,8 @@ namespace DbfDataReader
         public bool ReadFloatsAsDecimals { get; set; }
 
         public bool IsClosed => Stream == null;
+
+        internal long DataOffset => _startOffset + Header.HeaderLength;
 
         public void Close()
         {
@@ -183,6 +190,17 @@ namespace DbfDataReader
         public bool Read(DbfRecord dbfRecord)
         {
             return dbfRecord.Read(Stream);
+        }
+
+        public void Seek(int recordIndex)
+        {
+            if (recordIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(recordIndex), recordIndex,
+                    "Record index must not be negative.");
+            if (!Stream.CanSeek)
+                throw new NotSupportedException("The underlying stream does not support seeking.");
+
+            Stream.Seek(DataOffset + (long) recordIndex * Header.RecordLength, SeekOrigin.Begin);
         }
     }
 }

--- a/test/DbfDataReader.Tests/SeekTests.cs
+++ b/test/DbfDataReader.Tests/SeekTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests
+{
+    [Collection("dbase_03")]
+    public class SeekTests
+    {
+        private const string Dbase03FixturePath = "../../../../fixtures/dbase_03.dbf";
+        private const int Dbase03RecordCount = 14;
+
+        [Fact]
+        public void Should_track_record_index_while_reading_sequentially()
+        {
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfRecord.RecordIndex.ShouldBe(-1);
+
+            var expectedRecordIndex = 0;
+            while (dbfTable.Read(dbfRecord))
+            {
+                dbfRecord.RecordIndex.ShouldBe(expectedRecordIndex);
+                expectedRecordIndex++;
+            }
+
+            expectedRecordIndex.ShouldBe(Dbase03RecordCount);
+        }
+
+        [Fact]
+        public void Should_read_the_record_at_the_seeked_index()
+        {
+            var expectedValues = ReadFirstColumnValues();
+
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfTable.Seek(7);
+
+            dbfTable.Read(dbfRecord).ShouldBeTrue();
+            dbfRecord.RecordIndex.ShouldBe(7);
+            dbfRecord.GetStringValue(0).ShouldBe(expectedValues[7]);
+        }
+
+        [Fact]
+        public void Should_seek_back_to_the_first_record_after_reading_all_records()
+        {
+            var expectedValues = ReadFirstColumnValues();
+
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            while (dbfTable.Read(dbfRecord))
+            {
+            }
+
+            dbfTable.Seek(0);
+
+            dbfTable.Read(dbfRecord).ShouldBeTrue();
+            dbfRecord.RecordIndex.ShouldBe(0);
+            dbfRecord.GetStringValue(0).ShouldBe(expectedValues[0]);
+        }
+
+        [Fact]
+        public void Should_read_no_record_when_seeking_past_the_last_record()
+        {
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfTable.Seek(Dbase03RecordCount + 100);
+
+            dbfTable.Read(dbfRecord).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_throw_when_seeking_to_a_negative_record_index()
+        {
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+
+            Should.Throw<ArgumentOutOfRangeException>(() => dbfTable.Seek(-1));
+        }
+
+        [Fact]
+        public void Should_throw_when_seeking_a_non_seekable_stream()
+        {
+            using var fileStream = File.OpenRead(Dbase03FixturePath);
+            using var dbfTable = new DbfTable(new NonSeekableStream(fileStream));
+
+            Should.Throw<NotSupportedException>(() => dbfTable.Seek(0));
+        }
+
+        [Fact]
+        public void Should_seek_when_the_dbf_data_starts_at_a_non_zero_stream_offset()
+        {
+            var expectedValues = ReadFirstColumnValues();
+
+            const int padding = 64;
+            using var memoryStream = new MemoryStream();
+            memoryStream.Write(new byte[padding], 0, padding);
+            using (var fileStream = File.OpenRead(Dbase03FixturePath))
+            {
+                fileStream.CopyTo(memoryStream);
+            }
+            memoryStream.Position = padding;
+
+            using var dbfTable = new DbfTable(memoryStream);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfTable.Seek(2);
+
+            dbfTable.Read(dbfRecord).ShouldBeTrue();
+            dbfRecord.RecordIndex.ShouldBe(2);
+            dbfRecord.GetStringValue(0).ShouldBe(expectedValues[2]);
+        }
+
+        [Fact]
+        public void Should_seek_and_report_record_index_via_dbf_data_reader()
+        {
+            var expectedValues = ReadFirstColumnValues();
+
+            using var dbfDataReader = new DbfDataReader(Dbase03FixturePath);
+
+            dbfDataReader.Seek(5);
+
+            dbfDataReader.Read().ShouldBeTrue();
+            dbfDataReader.RecordIndex.ShouldBe(5);
+            dbfDataReader.GetString(0).ShouldBe(expectedValues[5]);
+        }
+
+        private static List<string> ReadFirstColumnValues()
+        {
+            var values = new List<string>();
+
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            while (dbfTable.Read(dbfRecord))
+            {
+                values.Add(dbfRecord.GetStringValue(0));
+            }
+
+            return values;
+        }
+
+        private sealed class NonSeekableStream : Stream
+        {
+            private readonly Stream _inner;
+
+            public NonSeekableStream(Stream inner)
+            {
+                _inner = inner;
+            }
+
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => _inner.Length;
+
+            public override long Position
+            {
+                get => _inner.Position;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() => _inner.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Reading has been strictly forward-only — no way to jump to a record by index, and no way to tell which record was just read. This adds:

- **`DbfTable.Seek(int recordIndex)`** — positions the table at the given zero-based record (`dataStart + recordIndex * RecordLength`). Also exposed as `DbfDataReader.Seek`. Negative indexes throw `ArgumentOutOfRangeException`; non-seekable streams throw `NotSupportedException`; seeking past the last record is allowed and simply makes the next `Read()` return `false` (deliberately not validated against `Header.RecordCount`, which is unreliable in real-world files).
- **`DbfRecord.RecordIndex`** — zero-based index of the record most recently read, `-1` before any read. Also exposed as `DbfDataReader.RecordIndex`. The value is derived from the stream position rather than a counter, so it stays correct across seeks and across multiple `DbfRecord`s reading interleaved from one table. With `SkipDeletedRecords`, it reports the file index of the record actually surfaced.
- The offset math accounts for streams where the DBF content starts at a non-zero position: the table captures the stream position at construction and bases all record offsets on it.

## Design notes
- Zero-based throughout, so `Seek(record.RecordIndex)` + `Read` re-reads the current record — one consistent convention. (xBase record numbers are traditionally 1-based; a future CDX index integration will convert in one documented place.)
- This is the groundwork step for CDX index support from the fork analysis: index searches yield record numbers that need `Seek` to become rows.

## Test plan
New `SeekTests` (8 tests): sequential `RecordIndex` tracking (-1 → 0..13), seek-then-read matches sequential values, rewind after full scan, seek past end reads nothing, negative index throws, non-seekable stream throws, DBF embedded at a non-zero stream offset seeks correctly, and the `DbfDataReader`-level `Seek`/`RecordIndex` path. Full suite: 112 passed, 1 skipped (pre-existing WIP skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)