### PR TITLE
Add asynchronous record reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ using (var dbfDataReader = new DbfDataReader(dbfPath, options))
 }
 ```
 
+Records can also be read asynchronously — `DbfDataReader` overrides `ReadAsync`, and `DbfTable` has `ReadAsync`/`ReadRecordAsync` counterparts. Each record is fetched with a single buffered asynchronous read and parsed in memory:
+
+```csharp
+var dbfPath = "path/file.dbf";
+using (var dbfDataReader = new DbfDataReader(dbfPath))
+{
+    while (await dbfDataReader.ReadAsync(cancellationToken))
+    {
+        var valueCol1 = dbfDataReader.GetString(0);
+    }
+}
+```
+
 Records can be accessed randomly by zero-based index using `Seek`, available on both `DbfTable` and `DbfDataReader`. The index of the record most recently read is available as `RecordIndex`:
 
 ```csharp

--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -5,6 +5,8 @@ using System.Data;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DbfDataReader
 {
@@ -154,6 +156,22 @@ namespace DbfDataReader
             do
             {
                 result = DbfTable.Read(DbfRecord);
+                if (!result)
+                    break;
+
+                skip = _options.SkipDeletedRecords && DbfRecord.IsDeleted;
+            } while (skip);
+
+            return result;
+        }
+
+        public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            bool result;
+            bool skip;
+            do
+            {
+                result = await DbfTable.ReadAsync(DbfRecord, cancellationToken).ConfigureAwait(false);
                 if (!result)
                     break;
 

--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Data.SqlTypes;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DbfDataReader
 {
@@ -121,25 +123,59 @@ namespace DbfDataReader
                         return false;
                     read += r;
                 }
-                var span = new ReadOnlySpan<byte>(_buffer);
 
-                var value = span[0];
-                if (value == EndOfFile) return false;
-
-                IsDeleted = value == 0x2A;
-                RecordIndex = (int) ((position - _dataOffset) / _recordLength);
-
-                foreach (var dbfValue in Values)
-                {
-                    var slice = span.Slice(dbfValue.Start, dbfValue.Length);
-                    dbfValue.Read(slice);
-                }
-                return true;
+                return ParseRecord(position);
             }
             catch (EndOfStreamException)
             {
                 return false;
             }
+        }
+
+        public async ValueTask<bool> ReadAsync(Stream stream, CancellationToken cancellationToken = default)
+        {
+            var position = stream.Position;
+            if (position == stream.Length) return false;
+
+            try
+            {
+                var read = await stream.ReadAsync(_buffer.AsMemory(0, _recordLength), cancellationToken)
+                    .ConfigureAwait(false);
+                if (read <= 0)
+                    return false;
+                while (read < _recordLength)
+                {
+                    var r = await stream.ReadAsync(_buffer.AsMemory(read, _recordLength - read), cancellationToken)
+                        .ConfigureAwait(false);
+                    if (r == 0)
+                        return false;
+                    read += r;
+                }
+
+                return ParseRecord(position);
+            }
+            catch (EndOfStreamException)
+            {
+                return false;
+            }
+        }
+
+        private bool ParseRecord(long position)
+        {
+            var span = new ReadOnlySpan<byte>(_buffer);
+
+            var value = span[0];
+            if (value == EndOfFile) return false;
+
+            IsDeleted = value == 0x2A;
+            RecordIndex = (int) ((position - _dataOffset) / _recordLength);
+
+            foreach (var dbfValue in Values)
+            {
+                var slice = span.Slice(dbfValue.Start, dbfValue.Length);
+                dbfValue.Read(slice);
+            }
+            return true;
         }
 
         public object GetValue(int ordinal)

--- a/src/DbfDataReader/DbfTable.cs
+++ b/src/DbfDataReader/DbfTable.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DbfDataReader
 {
@@ -187,9 +189,20 @@ namespace DbfDataReader
             return !dbfRecord.Read(Stream) ? null : dbfRecord;
         }
 
+        public async ValueTask<DbfRecord> ReadRecordAsync(CancellationToken cancellationToken = default)
+        {
+            var dbfRecord = new DbfRecord(this);
+            return !await dbfRecord.ReadAsync(Stream, cancellationToken).ConfigureAwait(false) ? null : dbfRecord;
+        }
+
         public bool Read(DbfRecord dbfRecord)
         {
             return dbfRecord.Read(Stream);
+        }
+
+        public ValueTask<bool> ReadAsync(DbfRecord dbfRecord, CancellationToken cancellationToken = default)
+        {
+            return dbfRecord.ReadAsync(Stream, cancellationToken);
         }
 
         public void Seek(int recordIndex)

--- a/test/DbfDataReader.Tests/AsyncReadTests.cs
+++ b/test/DbfDataReader.Tests/AsyncReadTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests
+{
+    [Collection("dbase_03")]
+    public class AsyncReadTests
+    {
+        private const string Dbase03FixturePath = "../../../../fixtures/dbase_03.dbf";
+        private const string Dbase30FixturePath = "../../../../fixtures/dbase_30.dbf";
+        private const int Dbase03RecordCount = 14;
+
+        [Fact]
+        public async Task Should_read_the_same_values_asynchronously_as_synchronously()
+        {
+            var expectedRows = ReadAllRowsAsStrings(Dbase03FixturePath);
+
+            var rows = new List<string>();
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            while (await dbfTable.ReadAsync(dbfRecord))
+            {
+                rows.Add(JoinValues(dbfRecord));
+            }
+
+            rows.ShouldBe(expectedRows);
+        }
+
+        [Fact]
+        public async Task Should_read_memo_values_asynchronously()
+        {
+            var expectedRows = ReadAllRowsAsStrings(Dbase30FixturePath);
+
+            var rows = new List<string>();
+            using var dbfTable = new DbfTable(Dbase30FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            while (await dbfTable.ReadAsync(dbfRecord))
+            {
+                rows.Add(JoinValues(dbfRecord));
+            }
+
+            rows.ShouldBe(expectedRows);
+        }
+
+        [Fact]
+        public async Task Should_track_record_index_when_reading_asynchronously()
+        {
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfRecord.RecordIndex.ShouldBe(-1);
+
+            var expectedRecordIndex = 0;
+            while (await dbfTable.ReadAsync(dbfRecord))
+            {
+                dbfRecord.RecordIndex.ShouldBe(expectedRecordIndex);
+                expectedRecordIndex++;
+            }
+
+            expectedRecordIndex.ShouldBe(Dbase03RecordCount);
+        }
+
+        [Fact]
+        public async Task Should_seek_then_read_asynchronously()
+        {
+            var expectedRows = ReadAllRowsAsStrings(Dbase03FixturePath);
+
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            dbfTable.Seek(7);
+
+            (await dbfTable.ReadAsync(dbfRecord)).ShouldBeTrue();
+            dbfRecord.RecordIndex.ShouldBe(7);
+            JoinValues(dbfRecord).ShouldBe(expectedRows[7]);
+        }
+
+        [Fact]
+        public async Task Should_read_records_asynchronously_with_read_record_async()
+        {
+            using var dbfTable = new DbfTable(Dbase03FixturePath);
+
+            var count = 0;
+            DbfRecord dbfRecord;
+            while ((dbfRecord = await dbfTable.ReadRecordAsync()) != null)
+            {
+                dbfRecord.RecordIndex.ShouldBe(count);
+                count++;
+            }
+
+            count.ShouldBe(Dbase03RecordCount);
+        }
+
+        [Fact]
+        public async Task Should_skip_deleted_records_when_reading_asynchronously()
+        {
+            var options = new DbfDataReaderOptions
+            {
+                SkipDeletedRecords = true
+            };
+
+            using var dbfDataReader = new DbfDataReader(Dbase03FixturePath, options);
+            var rowCount = 0;
+            while (await dbfDataReader.ReadAsync())
+            {
+                rowCount++;
+
+                _ = dbfDataReader.GetString(0);
+                _ = dbfDataReader.GetDecimal(10);
+            }
+
+            rowCount.ShouldBe(12);
+        }
+
+        [Fact]
+        public async Task Should_throw_when_reading_with_a_cancelled_token()
+        {
+            using var dbfDataReader = new DbfDataReader(Dbase03FixturePath);
+            var cancellationToken = new CancellationToken(canceled: true);
+
+            var exception = await Record.ExceptionAsync(() => dbfDataReader.ReadAsync(cancellationToken));
+
+            exception.ShouldBeAssignableTo<OperationCanceledException>();
+        }
+
+        private static string JoinValues(DbfRecord dbfRecord)
+        {
+            return string.Join("|", dbfRecord.Values.Select(v => v.ToString()));
+        }
+
+        private static List<string> ReadAllRowsAsStrings(string path)
+        {
+            var rows = new List<string>();
+
+            using var dbfTable = new DbfTable(path);
+            var dbfRecord = new DbfRecord(dbfTable);
+
+            while (dbfTable.Read(dbfRecord))
+            {
+                rows.Add(JoinValues(dbfRecord));
+            }
+
+            return rows;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds true async I/O to the read path — until now `DbfDataReader` inherited `DbDataReader`'s default `ReadAsync`, which just wraps the synchronous `Read()` in a completed task.

**Design: one buffered async read per record, synchronous parsing.** `DbfRecord.ReadAsync` fills the existing reused record buffer with `Stream.ReadAsync(Memory<byte>, CancellationToken)` (same partial-read loop as the sync path), then parses via the existing span-based value readers. The parse is shared with the sync path through a private `ParseRecord` (spans can't live in async methods, which makes the split natural). This is deliberately the opposite of the 2018 fork's approach (per-field async through a hand-ported async `BinaryReader`) — one awaited read per record instead of one per field, and a single code path for all value parsing.

**New API:**
- `DbfRecord.ReadAsync(Stream, CancellationToken)` → `ValueTask<bool>`
- `DbfTable.ReadAsync(DbfRecord, CancellationToken)` → `ValueTask<bool>`
- `DbfTable.ReadRecordAsync(CancellationToken)` → `ValueTask<DbfRecord>`
- `DbfDataReader.ReadAsync(CancellationToken)` — real override with the same skip-deleted loop as `Read()`

`ValueTask` internals mean no per-record task allocation when reads complete synchronously from the `FileStream` buffer (the common case); the `Task<bool>`-returning override benefits from the cached true/false task optimisation. Cancellation flows through to the underlying stream. `EndOfStreamException` handling matches the sync path.

**Scope notes:**
- File opening is unchanged (no `FileOptions.Asynchronous` by default — with one buffered read per record the handle mode matters little, and it would slow the dominant sync path; callers wanting a fully async handle can pass their own `FileStream` via the stream constructors).
- Memo values are still resolved synchronously during parsing (small seeked reads); can be made async separately.
- Possible follow-ups: async table open (`OpenAsync` for header/columns), `IAsyncEnumerable<DbfRecord>`.

## Test plan
New `AsyncReadTests` (7 tests): full-table async read compared row-by-row against the sync path (dbase_03, and dbase_30 to cover memo resolution inside async reads), `RecordIndex` tracking, `Seek` + `ReadAsync`, `ReadRecordAsync`, skip-deleted through the reader override (12 of 14 rows), and cancellation (pre-cancelled token throws `OperationCanceledException`). The existing `DbfDbConnection` tests already call `ExecuteReaderAsync`/`ReadAsync` and now exercise the real override. Full suite: 119 passed, 1 skipped (pre-existing WIP skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)