### PR TITLE
Execute column projection and TOP/LIMIT (SQL support phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ while (await reader.ReadAsync())
 }
 ```
 
+The command text supports column lists with optional aliases and a row limit:
+
+```sql
+select top 10 Point_ID as id, Date_Visit from dbase_03.dbf
+select Point_ID, Max_PDOP from dbase_03.dbf limit 5
+```
+
+`WHERE` and `ORDER BY` are parsed but not executable yet; they are being added in stages.
+
 The connection string supports the options available in `DbfDataReaderOptions`:
 
 - Folder - the folder containing the files to be queried

--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -298,68 +298,7 @@ namespace DbfDataReader
         public override DataTable GetSchemaTable()
         {
             var columnSchema = GetColumnSchema();
-            return GetSchemaTable(columnSchema);
+            return SchemaTableBuilder.Build(columnSchema);
         }
-
-        private static DataTable GetSchemaTable(ReadOnlyCollection<DbColumn> columnSchema)
-		{
-            var table = new DataTable("SchemaTable")
-            {
-                Columns =
-                {
-                    new DataColumn(SchemaTableColumn.ColumnName, typeof(string)),
-                    new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(int)),
-                    new DataColumn(SchemaTableColumn.ColumnSize, typeof(int)),
-                    new DataColumn(SchemaTableColumn.NumericPrecision, typeof(short)),
-                    new DataColumn(SchemaTableColumn.NumericScale, typeof(short)),
-                    new DataColumn(SchemaTableColumn.DataType, typeof(Type)),
-                    new DataColumn(SchemaTableColumn.AllowDBNull, typeof(bool)),
-                 
-                    new DataColumn(SchemaTableColumn.BaseColumnName, typeof(string)),
-                    new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(string)),
-                    new DataColumn(SchemaTableColumn.BaseTableName, typeof(string)),
-
-                    new DataColumn(SchemaTableColumn.IsAliased, typeof(bool)),
-                    new DataColumn(SchemaTableColumn.IsExpression, typeof(bool)),
-                    new DataColumn(SchemaTableColumn.IsKey, typeof(bool)),
-                    new DataColumn(SchemaTableColumn.IsLong, typeof(bool)),
-                    new DataColumn(SchemaTableColumn.IsUnique, typeof(bool)),
-
-                    new DataColumn(SchemaTableColumn.ProviderType, typeof(int)),
-                    new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(int)),
-                }
-            };
-
-            object dbNull = DBNull.Value;
-            foreach (var column in columnSchema)
-			{
-				var row = table.NewRow();
-				row[0] = column.ColumnName;
-				row[1] = column.ColumnOrdinal ?? dbNull;
-				row[2] = column.ColumnSize ?? dbNull;
-				row[3] = column.NumericPrecision ?? dbNull;
-				row[4] = column.NumericScale ?? dbNull;
-                row[5] = column.DataType ?? dbNull;
-				row[6] = column.AllowDBNull ?? dbNull;
-
-				row[7] = column.BaseColumnName ?? dbNull;
-				row[8] = column.BaseSchemaName ?? dbNull;
-				row[9] = column.BaseTableName ?? dbNull;
-
-				row[10] = column.IsAliased ?? dbNull;
-				row[11] = column.IsExpression ?? dbNull;
-				row[12] = column.IsKey ?? dbNull;
-				row[13] = column.IsLong ?? dbNull;
-				row[14] = column.IsUnique ?? dbNull;
-
-				var code = (int)Type.GetTypeCode(column.DataType);
-				row[15] = code;
-				row[16] = code;
-
-				table.Rows.Add(row);
-			}
-
-			return table;
-		}
     }
 }

--- a/src/DbfDataReader/DbfDbCommand.cs
+++ b/src/DbfDataReader/DbfDbCommand.cs
@@ -67,22 +67,31 @@ namespace DbfDataReader
             var filePath = GetFilePath(folder, statement.TableName);
 
             var options = dbfDbConnection.Options;
-            return new DbfDataReader(filePath, options);
+            var reader = new DbfDataReader(filePath, options);
+
+            // a plain SELECT * needs no projection or row limit; return the raw reader
+            if (statement.IsSelectAll && statement.Top == null) return reader;
+
+            try
+            {
+                SqlBinder.Bind(statement, reader.DbfTable.Columns);
+                return new DbfQueryDataReader(reader, statement);
+            }
+            catch
+            {
+                reader.Dispose();
+                throw;
+            }
         }
 
         // execution catches up with the parser in later phases; parse everything,
         // run what is implemented
         private static void EnsureSupported(SelectStatement statement)
         {
-            if (!statement.IsSelectAll)
-                throw new NotSupportedException(
-                    "Column selection is not supported yet; only 'SELECT *' can be executed.");
             if (statement.Where != null)
                 throw new NotSupportedException("WHERE clauses are not supported yet.");
             if (statement.OrderBy.Count > 0)
                 throw new NotSupportedException("ORDER BY is not supported yet.");
-            if (statement.Top != null)
-                throw new NotSupportedException("TOP and LIMIT are not supported yet.");
         }
 
         private static string GetFilePath(string folder, string fileName)

--- a/src/DbfDataReader/Query/DbfQueryColumn.cs
+++ b/src/DbfDataReader/Query/DbfQueryColumn.cs
@@ -1,0 +1,18 @@
+using System.Data.Common;
+
+namespace DbfDataReader.Query
+{
+    // schema for a projected column: the underlying column's shape under its output
+    // name and projected ordinal
+    internal sealed class DbfQueryColumn : DbColumn
+    {
+        public DbfQueryColumn(DbfColumn column, string outputName, int ordinal)
+        {
+            ColumnName = outputName;
+            ColumnOrdinal = ordinal;
+            DataType = column.DataType;
+            DataTypeName = column.DataTypeName;
+            BaseColumnName = column.ColumnName;
+        }
+    }
+}

--- a/src/DbfDataReader/Query/DbfQueryDataReader.cs
+++ b/src/DbfDataReader/Query/DbfQueryDataReader.cs
@@ -115,7 +115,11 @@ namespace DbfDataReader.Query
                 if (string.Equals(_names[ordinal], name, StringComparison.OrdinalIgnoreCase)) return ordinal;
             }
 
+            // DbDataReader.GetOrdinal is documented to throw IndexOutOfRangeException for
+            // unknown column names; DbfDataReader.GetOrdinal behaves the same way
+#pragma warning disable S112
             throw new IndexOutOfRangeException();
+#pragma warning restore S112
         }
 
         public override Type GetFieldType(int ordinal)

--- a/src/DbfDataReader/Query/DbfQueryDataReader.cs
+++ b/src/DbfDataReader/Query/DbfQueryDataReader.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbfDataReader.Query
+{
+    // wraps the raw table reader, exposing only the projected columns under their
+    // output names and enforcing the TOP/LIMIT row limit
+    internal sealed class DbfQueryDataReader : DbDataReader, IDbColumnSchemaGenerator
+    {
+        private readonly DbfDataReader _reader;
+        private readonly IReadOnlyList<DbfColumn> _columns; // underlying columns, in projected order
+        private readonly IReadOnlyList<int> _ordinals; // projected ordinal -> underlying ordinal
+        private readonly IReadOnlyList<string> _names; // output names (aliases applied)
+        private readonly int _limit; // -1 when unlimited
+        private int _rowsReturned;
+
+        public DbfQueryDataReader(DbfDataReader reader, SelectStatement statement)
+        {
+            _reader = reader;
+
+            var tableColumns = reader.DbfTable.Columns;
+            var columns = new List<DbfColumn>();
+            var ordinals = new List<int>();
+            var names = new List<string>();
+
+            if (statement.IsSelectAll)
+            {
+                for (var ordinal = 0; ordinal < tableColumns.Count; ordinal++)
+                {
+                    columns.Add(tableColumns[ordinal]);
+                    ordinals.Add(ordinal);
+                    names.Add(tableColumns[ordinal].ColumnName);
+                }
+            }
+            else
+            {
+                foreach (var selectColumn in statement.Columns)
+                {
+                    columns.Add(tableColumns[selectColumn.Ordinal]);
+                    ordinals.Add(selectColumn.Ordinal);
+                    names.Add(selectColumn.OutputName);
+                }
+            }
+
+            _columns = columns;
+            _ordinals = ordinals;
+            _names = names;
+            _limit = statement.Top ?? -1;
+        }
+
+        public override int FieldCount => _names.Count;
+
+        public override bool HasRows => _limit != 0 && _reader.HasRows;
+
+        public override bool IsClosed => _reader.IsClosed;
+
+        public override int Depth => 0;
+
+        public override int RecordsAffected => -1;
+
+        public override object this[int ordinal] => GetValue(ordinal);
+
+        public override object this[string name] => GetValue(GetOrdinal(name));
+
+        public override bool Read()
+        {
+            if (LimitReached()) return false;
+
+            var result = _reader.Read();
+            if (result) _rowsReturned++;
+
+            return result;
+        }
+
+        public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            if (LimitReached()) return false;
+
+            var result = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (result) _rowsReturned++;
+
+            return result;
+        }
+
+        private bool LimitReached()
+        {
+            return _limit >= 0 && _rowsReturned >= _limit;
+        }
+
+        public override bool NextResult()
+        {
+            return false;
+        }
+
+        public override string GetName(int ordinal)
+        {
+            return _names[ordinal];
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            for (var ordinal = 0; ordinal < _names.Count; ordinal++)
+            {
+                if (_names[ordinal] == name) return ordinal;
+            }
+
+            for (var ordinal = 0; ordinal < _names.Count; ordinal++)
+            {
+                if (string.Equals(_names[ordinal], name, StringComparison.OrdinalIgnoreCase)) return ordinal;
+            }
+
+            throw new IndexOutOfRangeException();
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            return _reader.GetFieldType(_ordinals[ordinal]);
+        }
+
+        public override string GetDataTypeName(int ordinal)
+        {
+            return _columns[ordinal].ColumnType.ToString();
+        }
+
+        public override object GetValue(int ordinal)
+        {
+            return _reader.GetValue(_ordinals[ordinal]);
+        }
+
+        public override int GetValues(object[] values)
+        {
+            for (var ordinal = 0; ordinal < FieldCount; ordinal++)
+            {
+                values[ordinal] = GetValue(ordinal);
+            }
+
+            return FieldCount;
+        }
+
+        public override bool IsDBNull(int ordinal)
+        {
+            return _reader.IsDBNull(_ordinals[ordinal]);
+        }
+
+        public override bool GetBoolean(int ordinal)
+        {
+            return _reader.GetBoolean(_ordinals[ordinal]);
+        }
+
+        public override byte GetByte(int ordinal)
+        {
+            return _reader.GetByte(_ordinals[ordinal]);
+        }
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            return _reader.GetBytes(_ordinals[ordinal], dataOffset, buffer, bufferOffset, length);
+        }
+
+        public override char GetChar(int ordinal)
+        {
+            return _reader.GetChar(_ordinals[ordinal]);
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            return _reader.GetChars(_ordinals[ordinal], dataOffset, buffer, bufferOffset, length);
+        }
+
+        public override DateTime GetDateTime(int ordinal)
+        {
+            return _reader.GetDateTime(_ordinals[ordinal]);
+        }
+
+        public override decimal GetDecimal(int ordinal)
+        {
+            return _reader.GetDecimal(_ordinals[ordinal]);
+        }
+
+        public override double GetDouble(int ordinal)
+        {
+            return _reader.GetDouble(_ordinals[ordinal]);
+        }
+
+        public override float GetFloat(int ordinal)
+        {
+            return _reader.GetFloat(_ordinals[ordinal]);
+        }
+
+        public override Guid GetGuid(int ordinal)
+        {
+            return _reader.GetGuid(_ordinals[ordinal]);
+        }
+
+        public override short GetInt16(int ordinal)
+        {
+            return _reader.GetInt16(_ordinals[ordinal]);
+        }
+
+        public override int GetInt32(int ordinal)
+        {
+            return _reader.GetInt32(_ordinals[ordinal]);
+        }
+
+        public override long GetInt64(int ordinal)
+        {
+            return _reader.GetInt64(_ordinals[ordinal]);
+        }
+
+        public override string GetString(int ordinal)
+        {
+            return _reader.GetString(_ordinals[ordinal]);
+        }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return new DbEnumerator(this, closeReader: false);
+        }
+
+        public ReadOnlyCollection<DbColumn> GetColumnSchema()
+        {
+            var schema = new List<DbColumn>(_columns.Count);
+            for (var ordinal = 0; ordinal < _columns.Count; ordinal++)
+            {
+                schema.Add(new DbfQueryColumn(_columns[ordinal], _names[ordinal], ordinal));
+            }
+
+            return schema.AsReadOnly();
+        }
+
+        public override DataTable GetSchemaTable()
+        {
+            return SchemaTableBuilder.Build(GetColumnSchema());
+        }
+
+        public override void Close()
+        {
+            _reader.Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                _reader.Dispose();
+            }
+        }
+    }
+}

--- a/src/DbfDataReader/SchemaTableBuilder.cs
+++ b/src/DbfDataReader/SchemaTableBuilder.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+namespace DbfDataReader
+{
+    internal static class SchemaTableBuilder
+    {
+        public static DataTable Build(IReadOnlyList<DbColumn> columnSchema)
+        {
+            var table = new DataTable("SchemaTable")
+            {
+                Columns =
+                {
+                    new DataColumn(SchemaTableColumn.ColumnName, typeof(string)),
+                    new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(int)),
+                    new DataColumn(SchemaTableColumn.ColumnSize, typeof(int)),
+                    new DataColumn(SchemaTableColumn.NumericPrecision, typeof(short)),
+                    new DataColumn(SchemaTableColumn.NumericScale, typeof(short)),
+                    new DataColumn(SchemaTableColumn.DataType, typeof(Type)),
+                    new DataColumn(SchemaTableColumn.AllowDBNull, typeof(bool)),
+
+                    new DataColumn(SchemaTableColumn.BaseColumnName, typeof(string)),
+                    new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(string)),
+                    new DataColumn(SchemaTableColumn.BaseTableName, typeof(string)),
+
+                    new DataColumn(SchemaTableColumn.IsAliased, typeof(bool)),
+                    new DataColumn(SchemaTableColumn.IsExpression, typeof(bool)),
+                    new DataColumn(SchemaTableColumn.IsKey, typeof(bool)),
+                    new DataColumn(SchemaTableColumn.IsLong, typeof(bool)),
+                    new DataColumn(SchemaTableColumn.IsUnique, typeof(bool)),
+
+                    new DataColumn(SchemaTableColumn.ProviderType, typeof(int)),
+                    new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(int)),
+                }
+            };
+
+            object dbNull = DBNull.Value;
+            foreach (var column in columnSchema)
+            {
+                var row = table.NewRow();
+                row[0] = column.ColumnName;
+                row[1] = column.ColumnOrdinal ?? dbNull;
+                row[2] = column.ColumnSize ?? dbNull;
+                row[3] = column.NumericPrecision ?? dbNull;
+                row[4] = column.NumericScale ?? dbNull;
+                row[5] = column.DataType ?? dbNull;
+                row[6] = column.AllowDBNull ?? dbNull;
+
+                row[7] = column.BaseColumnName ?? dbNull;
+                row[8] = column.BaseSchemaName ?? dbNull;
+                row[9] = column.BaseTableName ?? dbNull;
+
+                row[10] = column.IsAliased ?? dbNull;
+                row[11] = column.IsExpression ?? dbNull;
+                row[12] = column.IsKey ?? dbNull;
+                row[13] = column.IsLong ?? dbNull;
+                row[14] = column.IsUnique ?? dbNull;
+
+                var code = (int)Type.GetTypeCode(column.DataType);
+                row[15] = code;
+                row[16] = code;
+
+                table.Rows.Add(row);
+            }
+
+            return table;
+        }
+    }
+}

--- a/test/DbfDataReader.Tests/DbfDbCommandTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandTests.cs
@@ -33,10 +33,8 @@ public class DbfDbCommandTests
     }
 
     [Theory]
-    [InlineData("select Point_ID from dbase_03.dbf", "Column selection")]
     [InlineData("select * from dbase_03.dbf where Point_ID = 'x'", "WHERE")]
     [InlineData("select * from dbase_03.dbf order by Point_ID", "ORDER BY")]
-    [InlineData("select top 5 * from dbase_03.dbf", "TOP and LIMIT")]
     public void Should_throw_not_supported_for_parsed_but_unimplemented_features(string commandText,
         string expectedFragment)
     {

--- a/test/DbfDataReader.Tests/DbfQueryDataReaderTests.cs
+++ b/test/DbfDataReader.Tests/DbfQueryDataReaderTests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
+using DbfDataReader.Query;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+[Collection("dbase_03")]
+public class DbfQueryDataReaderTests
+{
+    private const string FolderPath = "../../../../fixtures";
+
+    private static DbfDbConnection OpenConnection()
+    {
+        var connection = new DbfDbConnection();
+        connection.ConnectionString = $"Folder={FolderPath};SkipDeletedRecords=false";
+        connection.Open();
+        return connection;
+    }
+
+    private static DbDataReader ExecuteReader(DbfDbConnection connection, string commandText)
+    {
+        var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        return command.ExecuteReader();
+    }
+
+    [Fact]
+    public void Should_project_columns()
+    {
+        var expected = ReadBaseline();
+
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Point_ID, Max_PDOP from dbase_03.dbf");
+
+        reader.FieldCount.ShouldBe(2);
+        reader.GetName(0).ShouldBe("Point_ID");
+        reader.GetName(1).ShouldBe("Max_PDOP");
+
+        var row = 0;
+        while (reader.Read())
+        {
+            reader.GetString(0).ShouldBe(expected[row].PointId);
+            reader.GetDecimal(1).ShouldBe(expected[row].MaxPdop);
+            row++;
+        }
+
+        row.ShouldBe(14);
+    }
+
+    [Fact]
+    public void Should_reorder_columns()
+    {
+        var expected = ReadBaseline();
+
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Max_PDOP, Point_ID from dbase_03.dbf");
+
+        reader.Read().ShouldBeTrue();
+        reader.GetDecimal(0).ShouldBe(expected[0].MaxPdop);
+        reader.GetString(1).ShouldBe(expected[0].PointId);
+    }
+
+    [Fact]
+    public void Should_apply_aliases()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Point_ID as id from dbase_03.dbf");
+
+        reader.GetName(0).ShouldBe("id");
+        reader.GetOrdinal("id").ShouldBe(0);
+        reader.GetOrdinal("ID").ShouldBe(0); // case-insensitive fallback
+
+        // the underlying name is replaced by the alias
+        Should.Throw<IndexOutOfRangeException>(() => reader.GetOrdinal("Point_ID"));
+    }
+
+    [Fact]
+    public void Should_allow_selecting_a_column_twice()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Point_ID, Point_ID as p2 from dbase_03.dbf");
+
+        reader.Read().ShouldBeTrue();
+        reader.GetString(1).ShouldBe(reader.GetString(0));
+    }
+
+    [Theory]
+    [InlineData("select top 5 * from dbase_03.dbf")]
+    [InlineData("select * from dbase_03.dbf limit 5")]
+    public void Should_limit_rows(string commandText)
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, commandText);
+
+        reader.FieldCount.ShouldBe(31);
+
+        var rowCount = 0;
+        while (reader.Read()) rowCount++;
+
+        rowCount.ShouldBe(5);
+    }
+
+    [Fact]
+    public void Should_return_all_rows_when_top_exceeds_the_record_count()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select top 100 * from dbase_03.dbf");
+
+        var rowCount = 0;
+        while (reader.Read()) rowCount++;
+
+        rowCount.ShouldBe(14);
+    }
+
+    [Fact]
+    public void Should_return_no_rows_for_top_zero()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select top 0 * from dbase_03.dbf");
+
+        reader.HasRows.ShouldBeFalse();
+        reader.Read().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_combine_projection_and_top()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select top 3 Point_ID from dbase_03.dbf");
+
+        reader.FieldCount.ShouldBe(1);
+
+        var rowCount = 0;
+        while (reader.Read()) rowCount++;
+
+        rowCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task Should_read_projected_rows_asynchronously()
+    {
+        var expected = ReadBaseline();
+
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select top 4 Point_ID from dbase_03.dbf");
+
+        var values = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        values.Count.ShouldBe(4);
+        values[3].ShouldBe(expected[3].PointId);
+    }
+
+    [Fact]
+    public void Should_expose_the_projected_schema()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Max_PDOP as pdop, Point_ID from dbase_03.dbf");
+
+        var schema = ((System.Data.Common.IDbColumnSchemaGenerator)reader).GetColumnSchema();
+        schema.Count.ShouldBe(2);
+        schema[0].ColumnName.ShouldBe("pdop");
+        schema[0].ColumnOrdinal.ShouldBe(0);
+        schema[0].DataType.ShouldBe(typeof(decimal));
+        schema[0].BaseColumnName.ShouldBe("Max_PDOP");
+        schema[1].ColumnName.ShouldBe("Point_ID");
+        schema[1].DataType.ShouldBe(typeof(string));
+
+        var schemaTable = reader.GetSchemaTable();
+        schemaTable.ShouldNotBeNull();
+        schemaTable.Rows.Count.ShouldBe(2);
+        schemaTable.Rows[0]["ColumnName"].ShouldBe("pdop");
+
+        reader.GetDataTypeName(0).ShouldBe("Number");
+        reader.GetDataTypeName(1).ShouldBe("Character");
+        reader.GetFieldType(1).ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void Should_keep_plain_select_all_on_the_raw_reader()
+    {
+        using var connection = OpenConnection();
+
+        using var plainReader = ExecuteReader(connection, "select * from dbase_03.dbf");
+        plainReader.ShouldBeOfType<DbfDataReader>();
+
+        using var limitedReader = ExecuteReader(connection, "select top 5 * from dbase_03.dbf");
+        limitedReader.ShouldNotBeOfType<DbfDataReader>();
+    }
+
+    [Fact]
+    public void Should_throw_for_unknown_projected_columns()
+    {
+        using var connection = OpenConnection();
+
+        var exception = Should.Throw<SqlParseException>(() =>
+            ExecuteReader(connection, "select nope from dbase_03.dbf"));
+
+        exception.Message.ShouldContain("Unknown column 'nope'");
+    }
+
+    [Fact]
+    public void Should_get_values_for_projected_columns()
+    {
+        using var connection = OpenConnection();
+        using var reader = ExecuteReader(connection, "select Point_ID, Max_PDOP from dbase_03.dbf");
+
+        reader.Read().ShouldBeTrue();
+
+        var values = new object[2];
+        reader.GetValues(values).ShouldBe(2);
+        values[0].ShouldBeOfType<string>();
+        values[1].ShouldBeOfType<decimal>();
+        reader["Point_ID"].ShouldBe(values[0]);
+        reader[1].ShouldBe(values[1]);
+    }
+
+    private static List<(string PointId, decimal MaxPdop)> ReadBaseline()
+    {
+        var rows = new List<(string, decimal)>();
+
+        using var dbfTable = new DbfTable($"{FolderPath}/dbase_03.dbf");
+        var dbfRecord = new DbfRecord(dbfTable);
+
+        while (dbfTable.Read(dbfRecord))
+        {
+            rows.Add((dbfRecord.GetValue<string>(0), dbfRecord.GetValue<decimal>(10)));
+        }
+
+        return rows;
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 of the SQL plan: the first user-visible SQL feature. Column lists, aliases, and row limits now execute:

```sql
select top 10 Point_ID as id, Date_Visit from dbase_03.dbf
select Point_ID, Max_PDOP from dbase_03.dbf limit 5
```

- **`DbfQueryDataReader`** (internal `DbDataReader`) wraps the raw table reader: projected-ordinal mapping for every typed getter, output names with aliases applied (`GetOrdinal` uses the same exact-then-case-insensitive rules as the raw reader; an aliased column's original name deliberately no longer resolves), `TOP`/`LIMIT` enforced in both `Read` and `ReadAsync`, `HasRows` false for `TOP 0`, and a correctly projected schema via `GetColumnSchema`/`GetSchemaTable` (output name + projected ordinal, `BaseColumnName` preserving the underlying column).
- **`DbfDbCommand`** binds the select list via `SqlBinder` (unknown columns throw `SqlParseException` with position; the just-opened reader is disposed on bind failure) and returns the query reader. A plain `SELECT *` with no limit still returns the raw `DbfDataReader` — zero overhead and bit-for-bit compatible, verified by a type assertion test.
- **`SchemaTableBuilder`** — the schema-table construction moved out of `DbfDataReader` into a shared internal helper used by both readers (logic unchanged).
- One deliberate contract improvement over the raw reader: `Depth` returns 0 and `RecordsAffected` returns -1 (the documented `DbDataReader` behaviour for SELECTs) instead of throwing — groundwork for the Dapper compatibility phase.

WHERE and ORDER BY still throw `NotSupportedException` — they're phases 3 and 4.

## Test plan
14 new tests in `DbfQueryDataReaderTests`, validated against baseline values read through the raw `DbfTable` API: projection, reordering, aliases (including the original-name-no-longer-resolves rule), duplicate column selection, `TOP`/`LIMIT`/`TOP 0`/over-count, projection+limit combined, async reads through the limit, projected schema (`GetColumnSchema`, `GetSchemaTable`, `GetFieldType`, `GetDataTypeName`), indexer/`GetValues` access, unknown-column errors, and the raw-reader-for-plain-`SELECT *` guarantee. Full suite: 238 passed, 1 pre-existing skip, zero warnings on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)