### PR TITLE
Execute WHERE clauses with parameters and ExecuteScalar (SQL support phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,29 @@ while (await reader.ReadAsync())
 }
 ```
 
-The command text supports column lists with optional aliases and a row limit:
+The command text supports column lists with optional aliases, a row limit, and `WHERE`
+clauses with named (`@name`) or positional (`?`) parameters:
 
 ```sql
 select top 10 Point_ID as id, Date_Visit from dbase_03.dbf
 select Point_ID, Max_PDOP from dbase_03.dbf limit 5
+select Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 and Date_Visit >= '1997-01-01'
+select Point_ID from dbase_03.dbf where Point_ID like 'A%' or Point_ID in ('B1', 'B2')
+select * from dbase_03.dbf where Point_ID = @id
 ```
 
-`WHERE` and `ORDER BY` are parsed but not executable yet; they are being added in stages.
+```csharp
+var command = (DbfDbCommand)dbConnection.CreateCommand();
+command.CommandText = "select Point_ID from dbase_03.dbf where Point_ID = @id";
+command.Parameters.AddWithValue("@id", "A1");
+var value = command.ExecuteScalar();
+```
+
+Predicates support `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `BETWEEN`, `IN`, `LIKE`
+(`%` and `_`), `IS [NOT] NULL`, `AND`/`OR`/`NOT` and parentheses. String comparisons are
+ordinal, case-sensitive and ignore trailing spaces; comparisons involving `NULL` follow
+SQL three-valued logic; date columns compare against `'yyyy-MM-dd'` or
+`'yyyy-MM-dd HH:mm:ss'` strings. `ORDER BY` is parsed but not executable yet.
 
 The connection string supports the options available in `DbfDataReaderOptions`:
 

--- a/src/DbfDataReader/DbfDbCommand.cs
+++ b/src/DbfDataReader/DbfDbCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.IO;
@@ -14,8 +15,10 @@ namespace DbfDataReader
         public override bool DesignTimeVisible { get; set; }
         public override UpdateRowSource UpdatedRowSource { get; set; }
         protected override DbConnection DbConnection { get; set; }
-        protected override DbParameterCollection DbParameterCollection { get; }
+        protected override DbParameterCollection DbParameterCollection { get; } = new DbfDbParameterCollection();
         protected override DbTransaction DbTransaction { get; set; }
+
+        public new DbfDbParameterCollection Parameters => (DbfDbParameterCollection)DbParameterCollection;
 
         public override void Cancel()
         {
@@ -29,7 +32,10 @@ namespace DbfDataReader
 
         public override object ExecuteScalar()
         {
-            throw new NotImplementedException();
+            using (var reader = ExecuteDbDataReader(CommandBehavior.Default))
+            {
+                return reader.Read() ? reader.GetValue(0) : null;
+            }
         }
 
         public override void Prepare()
@@ -39,7 +45,7 @@ namespace DbfDataReader
 
         protected override DbParameter CreateDbParameter()
         {
-            throw new NotImplementedException();
+            return new DbfDbParameter();
         }
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
@@ -69,13 +75,14 @@ namespace DbfDataReader
             var options = dbfDbConnection.Options;
             var reader = new DbfDataReader(filePath, options);
 
-            // a plain SELECT * needs no projection or row limit; return the raw reader
-            if (statement.IsSelectAll && statement.Top == null) return reader;
+            // a plain unfiltered SELECT * needs no projection, filter or row limit;
+            // return the raw reader
+            if (statement.IsSelectAll && statement.Top == null && statement.Where == null) return reader;
 
             try
             {
                 SqlBinder.Bind(statement, reader.DbfTable.Columns);
-                return new DbfQueryDataReader(reader, statement);
+                return new DbfQueryDataReader(reader, statement, CreateEvaluator(statement));
             }
             catch
             {
@@ -84,12 +91,28 @@ namespace DbfDataReader
             }
         }
 
+        private SqlExpressionEvaluator CreateEvaluator(SelectStatement statement)
+        {
+            if (statement.Where == null) return null;
+
+            var namedParameters = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            var positionalParameters = new List<object>();
+
+            foreach (DbfDbParameter parameter in Parameters)
+            {
+                positionalParameters.Add(parameter.Value);
+
+                var name = DbfDbParameterCollection.Normalize(parameter.ParameterName);
+                if (!string.IsNullOrEmpty(name)) namedParameters[name] = parameter.Value;
+            }
+
+            return new SqlExpressionEvaluator(statement.Where, namedParameters, positionalParameters);
+        }
+
         // execution catches up with the parser in later phases; parse everything,
         // run what is implemented
         private static void EnsureSupported(SelectStatement statement)
         {
-            if (statement.Where != null)
-                throw new NotSupportedException("WHERE clauses are not supported yet.");
             if (statement.OrderBy.Count > 0)
                 throw new NotSupportedException("ORDER BY is not supported yet.");
         }

--- a/src/DbfDataReader/DbfDbCommand.cs
+++ b/src/DbfDataReader/DbfDbCommand.cs
@@ -75,8 +75,8 @@ namespace DbfDataReader
             var options = dbfDbConnection.Options;
             var reader = new DbfDataReader(filePath, options);
 
-            // a plain unfiltered SELECT * needs no projection, filter or row limit;
-            // return the raw reader
+            // a plain unfiltered select-all needs no projection, filter or row limit,
+            // so it stays on the raw reader
             if (statement.IsSelectAll && statement.Top == null && statement.Where == null) return reader;
 
             try

--- a/src/DbfDataReader/DbfDbParameter.cs
+++ b/src/DbfDataReader/DbfDbParameter.cs
@@ -1,0 +1,29 @@
+using System.Data;
+using System.Data.Common;
+
+namespace DbfDataReader
+{
+    public class DbfDbParameter : DbParameter
+    {
+        public override DbType DbType { get; set; } = DbType.Object;
+
+        public override ParameterDirection Direction { get; set; } = ParameterDirection.Input;
+
+        public override bool IsNullable { get; set; }
+
+        public override string ParameterName { get; set; }
+
+        public override int Size { get; set; }
+
+        public override string SourceColumn { get; set; }
+
+        public override bool SourceColumnNullMapping { get; set; }
+
+        public override object Value { get; set; }
+
+        public override void ResetDbType()
+        {
+            DbType = DbType.Object;
+        }
+    }
+}

--- a/src/DbfDataReader/DbfDbParameterCollection.cs
+++ b/src/DbfDataReader/DbfDbParameterCollection.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace DbfDataReader
+{
+    public class DbfDbParameterCollection : DbParameterCollection
+    {
+        private readonly List<DbfDbParameter> _parameters = new List<DbfDbParameter>();
+
+        public override int Count => _parameters.Count;
+
+        public override object SyncRoot => ((ICollection)_parameters).SyncRoot;
+
+        public DbfDbParameter AddWithValue(string parameterName, object value)
+        {
+            var parameter = new DbfDbParameter { ParameterName = parameterName, Value = value };
+            _parameters.Add(parameter);
+            return parameter;
+        }
+
+        public override int Add(object value)
+        {
+            _parameters.Add(Cast(value));
+            return _parameters.Count - 1;
+        }
+
+        public override void AddRange(Array values)
+        {
+            foreach (var value in values)
+            {
+                Add(value);
+            }
+        }
+
+        public override void Clear()
+        {
+            _parameters.Clear();
+        }
+
+        public override bool Contains(object value)
+        {
+            return value is DbfDbParameter parameter && _parameters.Contains(parameter);
+        }
+
+        public override bool Contains(string value)
+        {
+            return IndexOf(value) >= 0;
+        }
+
+        public override void CopyTo(Array array, int index)
+        {
+            ((ICollection)_parameters).CopyTo(array, index);
+        }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return _parameters.GetEnumerator();
+        }
+
+        protected override DbParameter GetParameter(int index)
+        {
+            return _parameters[index];
+        }
+
+        protected override DbParameter GetParameter(string parameterName)
+        {
+            var index = IndexOf(parameterName);
+            if (index < 0) throw new ArgumentException($"Parameter '{parameterName}' was not found.");
+
+            return _parameters[index];
+        }
+
+        public override int IndexOf(object value)
+        {
+            return value is DbfDbParameter parameter ? _parameters.IndexOf(parameter) : -1;
+        }
+
+        public override int IndexOf(string parameterName)
+        {
+            for (var index = 0; index < _parameters.Count; index++)
+            {
+                if (NamesEqual(_parameters[index].ParameterName, parameterName)) return index;
+            }
+
+            return -1;
+        }
+
+        public override void Insert(int index, object value)
+        {
+            _parameters.Insert(index, Cast(value));
+        }
+
+        public override void Remove(object value)
+        {
+            if (value is DbfDbParameter parameter) _parameters.Remove(parameter);
+        }
+
+        public override void RemoveAt(int index)
+        {
+            _parameters.RemoveAt(index);
+        }
+
+        public override void RemoveAt(string parameterName)
+        {
+            var index = IndexOf(parameterName);
+            if (index >= 0) _parameters.RemoveAt(index);
+        }
+
+        protected override void SetParameter(int index, DbParameter value)
+        {
+            _parameters[index] = Cast(value);
+        }
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            var index = IndexOf(parameterName);
+            if (index < 0)
+            {
+                _parameters.Add(Cast(value));
+            }
+            else
+            {
+                _parameters[index] = Cast(value);
+            }
+        }
+
+        // parameter names match case-insensitively, with or without a leading '@'
+        private static bool NamesEqual(string x, string y)
+        {
+            return string.Equals(Normalize(x), Normalize(y), StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string Normalize(string parameterName)
+        {
+            return parameterName != null && parameterName.StartsWith("@", StringComparison.Ordinal)
+                ? parameterName.Substring(1)
+                : parameterName;
+        }
+
+        private static DbfDbParameter Cast(object value)
+        {
+            if (value is DbfDbParameter parameter) return parameter;
+
+            throw new InvalidCastException($"The value must be a {nameof(DbfDbParameter)}.");
+        }
+    }
+}

--- a/src/DbfDataReader/Query/DbfQueryDataReader.cs
+++ b/src/DbfDataReader/Query/DbfQueryDataReader.cs
@@ -17,12 +17,14 @@ namespace DbfDataReader.Query
         private readonly IReadOnlyList<DbfColumn> _columns; // underlying columns, in projected order
         private readonly IReadOnlyList<int> _ordinals; // projected ordinal -> underlying ordinal
         private readonly IReadOnlyList<string> _names; // output names (aliases applied)
+        private readonly SqlExpressionEvaluator _filter; // null when there is no WHERE clause
         private readonly int _limit; // -1 when unlimited
         private int _rowsReturned;
 
-        public DbfQueryDataReader(DbfDataReader reader, SelectStatement statement)
+        public DbfQueryDataReader(DbfDataReader reader, SelectStatement statement, SqlExpressionEvaluator filter)
         {
             _reader = reader;
+            _filter = filter;
 
             var tableColumns = reader.DbfTable.Columns;
             var columns = new List<DbfColumn>();
@@ -72,20 +74,30 @@ namespace DbfDataReader.Query
         {
             if (LimitReached()) return false;
 
-            var result = _reader.Read();
-            if (result) _rowsReturned++;
+            while (_reader.Read())
+            {
+                if (_filter != null && !_filter.Matches(_reader)) continue;
 
-            return result;
+                _rowsReturned++;
+                return true;
+            }
+
+            return false;
         }
 
         public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
             if (LimitReached()) return false;
 
-            var result = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-            if (result) _rowsReturned++;
+            while (await _reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_filter != null && !_filter.Matches(_reader)) continue;
 
-            return result;
+                _rowsReturned++;
+                return true;
+            }
+
+            return false;
         }
 
         private bool LimitReached()

--- a/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
+++ b/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace DbfDataReader.Query
+{
+    // Evaluates a bound WHERE expression against the current row of a reader, using SQL
+    // three-valued logic: comparisons involving NULL are unknown, and a row matches only
+    // when the whole expression is true. String comparisons are ordinal, case-sensitive
+    // and ignore trailing spaces, matching DBF MACHINE collation and CHAR padding.
+    internal sealed class SqlExpressionEvaluator
+    {
+        private static readonly string[] DateTimeFormats =
+        {
+            "yyyy-MM-dd",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-ddTHH:mm:ss"
+        };
+
+        private readonly SqlExpression _expression;
+        private readonly IReadOnlyDictionary<string, object> _namedParameters;
+        private readonly IReadOnlyList<object> _positionalParameters;
+        private readonly Dictionary<string, Regex> _likePatterns = new Dictionary<string, Regex>();
+
+        public SqlExpressionEvaluator(SqlExpression expression,
+            IReadOnlyDictionary<string, object> namedParameters, IReadOnlyList<object> positionalParameters)
+        {
+            _expression = expression;
+            _namedParameters = namedParameters;
+            _positionalParameters = positionalParameters;
+        }
+
+        public bool Matches(DbfDataReader reader)
+        {
+            return EvaluateCondition(_expression, reader) == true;
+        }
+
+        private bool? EvaluateCondition(SqlExpression expression, DbfDataReader reader)
+        {
+            switch (expression)
+            {
+                case SqlBinaryExpression binary:
+                    return EvaluateBinary(binary, reader);
+                case SqlNotExpression not:
+                    return Negate(EvaluateCondition(not.Operand, reader));
+                case SqlBetweenExpression between:
+                    return EvaluateBetween(between, reader);
+                case SqlInExpression inExpression:
+                    return EvaluateIn(inExpression, reader);
+                case SqlLikeExpression like:
+                    return EvaluateLike(like, reader);
+                case SqlIsNullExpression isNull:
+                    return EvaluateIsNull(isNull, reader);
+                default:
+                    throw new InvalidOperationException(
+                        $"The expression at position {expression.Position} cannot be used as a condition.");
+            }
+        }
+
+        private bool? EvaluateBinary(SqlBinaryExpression binary, DbfDataReader reader)
+        {
+            switch (binary.Operator)
+            {
+                case SqlBinaryOperator.And:
+                    return EvaluateAnd(binary, reader);
+                case SqlBinaryOperator.Or:
+                    return EvaluateOr(binary, reader);
+                default:
+                    return EvaluateComparison(binary, reader);
+            }
+        }
+
+        private bool? EvaluateAnd(SqlBinaryExpression binary, DbfDataReader reader)
+        {
+            var left = EvaluateCondition(binary.Left, reader);
+            if (left == false) return false;
+
+            var right = EvaluateCondition(binary.Right, reader);
+            if (right == false) return false;
+
+            return left == true && right == true ? true : (bool?)null;
+        }
+
+        private bool? EvaluateOr(SqlBinaryExpression binary, DbfDataReader reader)
+        {
+            var left = EvaluateCondition(binary.Left, reader);
+            if (left == true) return true;
+
+            var right = EvaluateCondition(binary.Right, reader);
+            if (right == true) return true;
+
+            return left == false && right == false ? false : (bool?)null;
+        }
+
+        private bool? EvaluateComparison(SqlBinaryExpression binary, DbfDataReader reader)
+        {
+            var left = EvaluateOperand(binary.Left, reader);
+            var right = EvaluateOperand(binary.Right, reader);
+            if (left == null || right == null) return null;
+
+            var cmp = CompareValues(left, right, binary.Position);
+            switch (binary.Operator)
+            {
+                case SqlBinaryOperator.Equal: return cmp == 0;
+                case SqlBinaryOperator.NotEqual: return cmp != 0;
+                case SqlBinaryOperator.LessThan: return cmp < 0;
+                case SqlBinaryOperator.LessThanOrEqual: return cmp <= 0;
+                case SqlBinaryOperator.GreaterThan: return cmp > 0;
+                case SqlBinaryOperator.GreaterThanOrEqual: return cmp >= 0;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected operator at position {binary.Position}.");
+            }
+        }
+
+        private bool? EvaluateBetween(SqlBetweenExpression between, DbfDataReader reader)
+        {
+            var value = EvaluateOperand(between.Operand, reader);
+            var low = EvaluateOperand(between.Low, reader);
+            var high = EvaluateOperand(between.High, reader);
+
+            var lowerBound = value == null || low == null
+                ? (bool?)null
+                : CompareValues(value, low, between.Position) >= 0;
+            if (lowerBound == false) return ApplyNegation(false, between.Negated);
+
+            var upperBound = value == null || high == null
+                ? (bool?)null
+                : CompareValues(value, high, between.Position) <= 0;
+
+            var result = lowerBound == true && upperBound == true
+                ? true
+                : upperBound == false
+                    ? false
+                    : (bool?)null;
+
+            return ApplyNegation(result, between.Negated);
+        }
+
+        private bool? EvaluateIn(SqlInExpression inExpression, DbfDataReader reader)
+        {
+            var value = EvaluateOperand(inExpression.Operand, reader);
+
+            var sawUnknown = value == null;
+            var found = false;
+
+            if (value != null)
+            {
+                foreach (var valueExpression in inExpression.Values)
+                {
+                    var element = EvaluateOperand(valueExpression, reader);
+                    if (element == null)
+                    {
+                        sawUnknown = true;
+                        continue;
+                    }
+
+                    if (CompareValues(value, element, inExpression.Position) == 0)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            var result = found ? true : sawUnknown ? (bool?)null : false;
+            return ApplyNegation(result, inExpression.Negated);
+        }
+
+        private bool? EvaluateLike(SqlLikeExpression like, DbfDataReader reader)
+        {
+            var value = EvaluateOperand(like.Operand, reader);
+            var pattern = EvaluateOperand(like.Pattern, reader);
+            if (value == null || pattern == null) return null;
+
+            if (!(value is string text))
+                throw new InvalidOperationException(
+                    $"LIKE requires a character operand at position {like.Position}.");
+            if (!(pattern is string patternText))
+                throw new InvalidOperationException(
+                    $"LIKE requires a character pattern at position {like.Position}.");
+
+            var result = GetLikePattern(patternText).IsMatch(TrimTrailingSpaces(text));
+            return ApplyNegation(result, like.Negated);
+        }
+
+        private bool? EvaluateIsNull(SqlIsNullExpression isNull, DbfDataReader reader)
+        {
+            var value = EvaluateOperand(isNull.Operand, reader);
+            return isNull.Negated ? value != null : value == null;
+        }
+
+        private object EvaluateOperand(SqlExpression expression, DbfDataReader reader)
+        {
+            switch (expression)
+            {
+                case SqlLiteralExpression literal:
+                    return literal.Value;
+                case SqlColumnExpression column:
+                    return reader.GetValue(column.Ordinal);
+                case SqlParameterExpression parameter:
+                    return GetParameterValue(parameter);
+                default:
+                    throw new InvalidOperationException(
+                        $"The expression at position {expression.Position} cannot be used as a value.");
+            }
+        }
+
+        private object GetParameterValue(SqlParameterExpression parameter)
+        {
+            object value;
+            if (parameter.Name != null)
+            {
+                if (_namedParameters == null || !_namedParameters.TryGetValue(parameter.Name, out value))
+                    throw new InvalidOperationException($"Parameter '@{parameter.Name}' was not supplied.");
+            }
+            else
+            {
+                if (_positionalParameters == null || parameter.Index >= _positionalParameters.Count)
+                    throw new InvalidOperationException(
+                        $"Positional parameter {parameter.Index + 1} was not supplied.");
+
+                value = _positionalParameters[parameter.Index];
+            }
+
+            if (value == null || value is DBNull) return null;
+            if (value is char character) return character.ToString(CultureInfo.InvariantCulture);
+
+            return value;
+        }
+
+        private static int CompareValues(object left, object right, int position)
+        {
+            if (left is string leftText && right is string rightText)
+                return string.CompareOrdinal(TrimTrailingSpaces(leftText), TrimTrailingSpaces(rightText));
+
+            if (IsNumber(left) && IsNumber(right)) return CompareNumbers(left, right);
+
+            if (left is DateTime || right is DateTime)
+                return ToDateTime(left, position).CompareTo(ToDateTime(right, position));
+
+            if (left is bool leftBool && right is bool rightBool) return leftBool.CompareTo(rightBool);
+
+            throw new InvalidOperationException(
+                $"Cannot compare values of type {left.GetType().Name} and {right.GetType().Name} " +
+                $"at position {position}.");
+        }
+
+        private static int CompareNumbers(object left, object right)
+        {
+            if (left is double || left is float || right is double || right is float)
+                return Convert.ToDouble(left, CultureInfo.InvariantCulture)
+                    .CompareTo(Convert.ToDouble(right, CultureInfo.InvariantCulture));
+
+            return Convert.ToDecimal(left, CultureInfo.InvariantCulture)
+                .CompareTo(Convert.ToDecimal(right, CultureInfo.InvariantCulture));
+        }
+
+        private static bool IsNumber(object value)
+        {
+            switch (value)
+            {
+                case byte _:
+                case sbyte _:
+                case short _:
+                case ushort _:
+                case int _:
+                case uint _:
+                case long _:
+                case ulong _:
+                case float _:
+                case double _:
+                case decimal _:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static DateTime ToDateTime(object value, int position)
+        {
+            switch (value)
+            {
+                case DateTime dateTime:
+                    return dateTime;
+                case string text:
+                    if (DateTime.TryParseExact(text, DateTimeFormats, CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var parsed))
+                        return parsed;
+
+                    throw new InvalidOperationException(
+                        $"Cannot convert '{text}' to a date at position {position}; " +
+                        "use 'yyyy-MM-dd' or 'yyyy-MM-dd HH:mm:ss'.");
+                default:
+                    throw new InvalidOperationException(
+                        $"Cannot compare a date with a value of type {value.GetType().Name} " +
+                        $"at position {position}.");
+            }
+        }
+
+        private Regex GetLikePattern(string pattern)
+        {
+            if (_likePatterns.TryGetValue(pattern, out var regex)) return regex;
+
+            var translated = "^" + Regex.Escape(pattern).Replace("%", ".*").Replace("_", ".") + "$";
+            regex = new Regex(translated, RegexOptions.Singleline, TimeSpan.FromMilliseconds(100));
+            _likePatterns[pattern] = regex;
+
+            return regex;
+        }
+
+        private static bool? Negate(bool? value)
+        {
+            return value == null ? (bool?)null : !value.Value;
+        }
+
+        private static bool? ApplyNegation(bool? value, bool negated)
+        {
+            return negated ? Negate(value) : value;
+        }
+
+        private static string TrimTrailingSpaces(string value)
+        {
+            return value.TrimEnd(' ');
+        }
+    }
+}

--- a/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
+++ b/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
@@ -129,11 +129,10 @@ namespace DbfDataReader.Query
                 ? (bool?)null
                 : CompareValues(value, high, between.Position) <= 0;
 
-            var result = lowerBound == true && upperBound == true
-                ? true
-                : upperBound == false
-                    ? false
-                    : (bool?)null;
+            bool? result;
+            if (upperBound == false) result = false;
+            else if (lowerBound == true && upperBound == true) result = true;
+            else result = null;
 
             return ApplyNegation(result, between.Negated);
         }
@@ -164,7 +163,11 @@ namespace DbfDataReader.Query
                 }
             }
 
-            var result = found ? true : sawUnknown ? (bool?)null : false;
+            bool? result;
+            if (found) result = true;
+            else if (sawUnknown) result = null;
+            else result = false;
+
             return ApplyNegation(result, inExpression.Negated);
         }
 

--- a/test/DbfDataReader.Tests/DbfDbCommandTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandTests.cs
@@ -33,7 +33,6 @@ public class DbfDbCommandTests
     }
 
     [Theory]
-    [InlineData("select * from dbase_03.dbf where Point_ID = 'x'", "WHERE")]
     [InlineData("select * from dbase_03.dbf order by Point_ID", "ORDER BY")]
     public void Should_throw_not_supported_for_parsed_but_unimplemented_features(string commandText,
         string expectedFragment)

--- a/test/DbfDataReader.Tests/DbfDbCommandWhereTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandWhereTests.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+[Collection("dbase_03")]
+public class DbfDbCommandWhereTests
+{
+    private const string FolderPath = "../../../../fixtures";
+
+    // every SQL result is checked against an oracle: the same predicate applied in C#
+    // (with the dialect's semantics) over a full scan of the fixture
+    private sealed record BaselineRow(string PointId, decimal MaxPdop, DateTime? DateVisit);
+
+    private static List<BaselineRow> ReadBaseline()
+    {
+        var rows = new List<BaselineRow>();
+
+        using var dbfTable = new DbfTable($"{FolderPath}/dbase_03.dbf");
+        var dbfRecord = new DbfRecord(dbfTable);
+
+        while (dbfTable.Read(dbfRecord))
+        {
+            rows.Add(new BaselineRow(
+                dbfRecord.GetValue<string>(0),
+                dbfRecord.GetValue<decimal>(10),
+                (DateTime?)dbfRecord.GetValue(8)));
+        }
+
+        return rows;
+    }
+
+    private static DbfDbConnection OpenConnection()
+    {
+        var connection = new DbfDbConnection();
+        connection.ConnectionString = $"Folder={FolderPath};SkipDeletedRecords=false";
+        connection.Open();
+        return connection;
+    }
+
+    private static List<string> QueryPointIds(string commandText, Action<DbfDbCommand> configure = null)
+    {
+        using var connection = OpenConnection();
+        var command = (DbfDbCommand)connection.CreateCommand();
+        command.CommandText = commandText;
+        configure?.Invoke(command);
+
+        var results = new List<string>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        return results;
+    }
+
+    [Fact]
+    public void Should_filter_by_string_equality()
+    {
+        var baseline = ReadBaseline();
+        var target = baseline[3].PointId;
+        var expected = baseline.Where(r => r.PointId == target).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds($"select Point_ID from dbase_03.dbf where Point_ID = '{target}'");
+
+        actual.ShouldBe(expected);
+        actual.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Should_ignore_trailing_spaces_in_string_equality()
+    {
+        var baseline = ReadBaseline();
+        var target = baseline[3].PointId;
+
+        var actual = QueryPointIds($"select Point_ID from dbase_03.dbf where Point_ID = '{target}   '");
+
+        actual.ShouldContain(target);
+    }
+
+    [Fact]
+    public void Should_filter_with_numeric_comparisons()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var expected = baseline.Where(r => r.MaxPdop >= threshold).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            $"select Point_ID from dbase_03.dbf where Max_PDOP >= {threshold.ToString(CultureInfo.InvariantCulture)}");
+
+        actual.ShouldBe(expected);
+        actual.Count.ShouldBeInRange(1, 13); // a threshold from the data always splits the rows
+    }
+
+    [Fact]
+    public void Should_filter_with_between()
+    {
+        var baseline = ReadBaseline();
+        var low = baseline.Min(r => r.MaxPdop);
+        var high = baseline[7].MaxPdop;
+        var expected = baseline.Where(r => r.MaxPdop >= low && r.MaxPdop <= high).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            "select Point_ID from dbase_03.dbf where Max_PDOP between " +
+            $"{low.ToString(CultureInfo.InvariantCulture)} and {high.ToString(CultureInfo.InvariantCulture)}");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_filter_with_in_lists()
+    {
+        var baseline = ReadBaseline();
+        var first = baseline.First().PointId;
+        var last = baseline.Last().PointId;
+        var expected = baseline
+            .Where(r => r.PointId == first || r.PointId == last)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            $"select Point_ID from dbase_03.dbf where Point_ID in ('{first}', '{last}', 'no-such-value')");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_filter_with_like_prefixes()
+    {
+        var baseline = ReadBaseline();
+        var prefix = baseline[0].PointId.Substring(0, 2);
+        var expected = baseline
+            .Where(r => r.PointId != null && r.PointId.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds($"select Point_ID from dbase_03.dbf where Point_ID like '{prefix}%'");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_filter_by_date_comparison()
+    {
+        var baseline = ReadBaseline();
+        var pivot = baseline.Where(r => r.DateVisit != null).Select(r => r.DateVisit.Value).OrderBy(d => d)
+            .ElementAt(baseline.Count / 2);
+        var expected = baseline
+            .Where(r => r.DateVisit != null && r.DateVisit.Value >= pivot)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            $"select Point_ID from dbase_03.dbf where Date_Visit >= '{pivot:yyyy-MM-dd}'");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_combine_predicates_with_and_or_not()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var first = baseline.First().PointId;
+        var expected = baseline
+            .Where(r => (r.PointId == first || r.MaxPdop > threshold) && !(r.PointId == null))
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            $"select Point_ID from dbase_03.dbf where (Point_ID = '{first}' or Max_PDOP > " +
+            $"{threshold.ToString(CultureInfo.InvariantCulture)}) and not (Point_ID is null)");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_partition_rows_between_is_null_and_is_not_null()
+    {
+        var nullCount = QueryPointIds("select Point_ID from dbase_03.dbf where Point_ID is null").Count;
+        var notNullCount = QueryPointIds("select Point_ID from dbase_03.dbf where Point_ID is not null").Count;
+
+        (nullCount + notNullCount).ShouldBe(14);
+    }
+
+    [Fact]
+    public void Should_return_no_rows_when_comparing_with_null()
+    {
+        QueryPointIds("select Point_ID from dbase_03.dbf where Point_ID = null").ShouldBeEmpty();
+        QueryPointIds("select Point_ID from dbase_03.dbf where not (Point_ID = null)").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_filter_select_star_queries()
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select * from dbase_03.dbf where Point_ID is null";
+
+        using var reader = command.ExecuteReader();
+        reader.FieldCount.ShouldBe(31);
+        reader.Read().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_apply_top_after_the_filter()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var expected = baseline.Where(r => r.MaxPdop >= threshold).Take(2).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds(
+            "select top 2 Point_ID from dbase_03.dbf where Max_PDOP >= " +
+            threshold.ToString(CultureInfo.InvariantCulture));
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_filter_with_named_parameters()
+    {
+        var baseline = ReadBaseline();
+        var target = baseline[5].PointId;
+        var expected = baseline.Where(r => r.PointId == target).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds("select Point_ID from dbase_03.dbf where Point_ID = @id",
+            command => command.Parameters.AddWithValue("@id", target));
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_filter_with_positional_parameters()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var expected = baseline.Where(r => r.MaxPdop >= threshold).Select(r => r.PointId).ToList();
+
+        var actual = QueryPointIds("select Point_ID from dbase_03.dbf where Max_PDOP >= ?",
+            command => command.Parameters.AddWithValue("threshold", threshold));
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_throw_for_missing_parameters_when_reading()
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID from dbase_03.dbf where Point_ID = @id";
+
+        using var reader = command.ExecuteReader();
+        var exception = Should.Throw<InvalidOperationException>(() => reader.Read());
+
+        exception.Message.ShouldContain("Parameter '@id' was not supplied");
+    }
+
+    [Fact]
+    public void Should_throw_for_type_mismatches_when_reading()
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID from dbase_03.dbf where Point_ID > 5";
+
+        using var reader = command.ExecuteReader();
+        var exception = Should.Throw<InvalidOperationException>(() => reader.Read());
+
+        exception.Message.ShouldContain("Cannot compare");
+    }
+
+    [Fact]
+    public async Task Should_filter_asynchronously()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var expected = baseline.Where(r => r.MaxPdop >= threshold).Select(r => r.PointId).ToList();
+
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID from dbase_03.dbf where Max_PDOP >= " +
+                              threshold.ToString(CultureInfo.InvariantCulture);
+
+        var actual = new List<string>();
+        var reader = await command.ExecuteReaderAsync();
+        await using (reader.ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync())
+            {
+                actual.Add(reader.GetString(0));
+            }
+        }
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_execute_scalar()
+    {
+        var baseline = ReadBaseline();
+        var target = baseline[2].PointId;
+
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = $"select Point_ID from dbase_03.dbf where Point_ID = '{target}'";
+
+        command.ExecuteScalar().ShouldBe(target);
+    }
+
+    [Fact]
+    public void Should_execute_scalar_returning_null_for_no_rows()
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID from dbase_03.dbf where Point_ID = 'no-such-value'";
+
+        command.ExecuteScalar().ShouldBeNull();
+    }
+}

--- a/test/DbfDataReader.Tests/SqlExpressionEvaluatorTests.cs
+++ b/test/DbfDataReader.Tests/SqlExpressionEvaluatorTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using DbfDataReader.Query;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+public class SqlExpressionEvaluatorTests
+{
+    // literal- and parameter-only expressions never touch the row, so the evaluator can
+    // run without a reader; this exercises the coercion matrix and three-valued logic
+    // in isolation
+    private static bool Matches(string where, Dictionary<string, object> named = null,
+        List<object> positional = null)
+    {
+        var statement = SqlParser.Parse($"select * from t.dbf where {where}");
+        var evaluator = new SqlExpressionEvaluator(statement.Where, named, positional);
+        return evaluator.Matches(null);
+    }
+
+    [Theory]
+    [InlineData("1 = 1", true)]
+    [InlineData("1 = 2", false)]
+    [InlineData("1 = 1.0", true)]
+    [InlineData("1.5 > 1", true)]
+    [InlineData("-2 < -1", true)]
+    [InlineData("2 <> 3", true)]
+    [InlineData("2 <= 2", true)]
+    [InlineData("3 >= 4", false)]
+    public void Should_compare_numbers(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("'ab' = 'ab'", true)]
+    [InlineData("'ab' = 'ab   '", true)] // trailing spaces are ignored
+    [InlineData("'ab' = 'AB'", false)] // ordinal, case-sensitive
+    [InlineData("'abc' < 'abd'", true)]
+    [InlineData("' ab' = 'ab'", false)] // leading spaces are significant
+    public void Should_compare_strings(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("true = true", true)]
+    [InlineData("true <> false", true)]
+    [InlineData("false = true", false)]
+    public void Should_compare_booleans(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("null = null", false)] // unknown, not true
+    [InlineData("not (null = null)", false)] // NOT unknown stays unknown
+    [InlineData("null is null", true)]
+    [InlineData("null is not null", false)]
+    [InlineData("1 is not null", true)]
+    [InlineData("null = 1 or 1 = 1", true)] // unknown OR true = true
+    [InlineData("null = 1 and 1 = 1", false)] // unknown AND true = unknown
+    [InlineData("1 = 2 and null = 1", false)] // false AND unknown = false
+    [InlineData("not (1 = 2 and null = 1)", true)] // NOT false = true
+    public void Should_apply_three_valued_logic(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("'abc' like 'a%'", true)]
+    [InlineData("'abc' like '%c'", true)]
+    [InlineData("'abc' like 'a_c'", true)]
+    [InlineData("'abc' like 'a_d'", false)]
+    [InlineData("'a.c' like 'a_c'", true)]
+    [InlineData("'axc' like 'a.c'", false)] // regex characters in the pattern are literal
+    [InlineData("'abc' like 'A%'", false)] // case-sensitive
+    [InlineData("'abc' not like 'b%'", true)]
+    [InlineData("'abc   ' like 'abc'", true)] // trailing spaces on the value are ignored
+    [InlineData("'abc' like null", false)] // unknown
+    public void Should_evaluate_like(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("1 in (1, 2)", true)]
+    [InlineData("3 in (1, 2)", false)]
+    [InlineData("1 in (null, 1)", true)] // found despite the null element
+    [InlineData("3 in (1, null)", false)] // unknown, not false
+    [InlineData("3 not in (1, 2)", true)]
+    [InlineData("3 not in (1, null)", false)] // NOT unknown stays unknown
+    [InlineData("'b' in ('a', 'b')", true)]
+    public void Should_evaluate_in(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("2 between 1 and 3", true)]
+    [InlineData("0 between 1 and 3", false)]
+    [InlineData("4 between 1 and 3", false)]
+    [InlineData("2 not between 1 and 3", false)]
+    [InlineData("0 not between 1 and 3", true)]
+    [InlineData("null between 1 and 3", false)] // unknown
+    [InlineData("2 between null and 3", false)] // unknown
+    [InlineData("0 between 1 and null", false)] // below the lower bound: definitively false
+    [InlineData("0 not between 1 and null", true)]
+    [InlineData("'b' between 'a' and 'c'", true)]
+    public void Should_evaluate_between(string where, bool expected)
+    {
+        Matches(where).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_coerce_date_strings_when_compared_with_dates()
+    {
+        var named = new Dictionary<string, object> { ["d"] = new DateTime(2020, 6, 15) };
+
+        Matches("@d >= '2020-01-01'", named).ShouldBeTrue();
+        Matches("@d = '2020-06-15'", named).ShouldBeTrue();
+        Matches("@d < '2020-06-15 00:00:01'", named).ShouldBeTrue();
+        Matches("@d between '2020-01-01' and '2020-12-31'", named).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Should_throw_for_unparseable_date_strings()
+    {
+        var named = new Dictionary<string, object> { ["d"] = new DateTime(2020, 6, 15) };
+
+        var exception = Should.Throw<InvalidOperationException>(() => Matches("@d = 'not-a-date'", named));
+
+        exception.Message.ShouldContain("Cannot convert 'not-a-date' to a date");
+    }
+
+    [Fact]
+    public void Should_resolve_named_and_positional_parameters()
+    {
+        var named = new Dictionary<string, object> { ["id"] = 5 };
+        var positional = new List<object> { 7 };
+
+        Matches("@id = 5", named).ShouldBeTrue();
+        Matches("? = 7", positional: positional).ShouldBeTrue();
+        Matches("@id = 5.0", named).ShouldBeTrue(); // int parameter vs decimal literal
+    }
+
+    [Fact]
+    public void Should_treat_dbnull_parameters_as_null()
+    {
+        var named = new Dictionary<string, object> { ["id"] = DBNull.Value };
+
+        Matches("@id = 1", named).ShouldBeFalse(); // unknown
+        Matches("@id is null", named).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Should_compare_char_parameters_as_strings()
+    {
+        var named = new Dictionary<string, object> { ["c"] = 'x' };
+
+        Matches("@c = 'x'", named).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("@missing = 1", "Parameter '@missing' was not supplied")]
+    [InlineData("? = 1", "Positional parameter 1 was not supplied")]
+    public void Should_throw_for_missing_parameters(string where, string expectedFragment)
+    {
+        var exception = Should.Throw<InvalidOperationException>(() => Matches(where));
+
+        exception.Message.ShouldContain(expectedFragment);
+    }
+
+    [Fact]
+    public void Should_throw_for_type_mismatches_with_the_position()
+    {
+        var exception = Should.Throw<InvalidOperationException>(() => Matches("'a' > 1"));
+
+        exception.Message.ShouldContain("Cannot compare");
+        exception.Message.ShouldContain("position");
+    }
+
+    [Fact]
+    public void Should_throw_for_like_on_non_string_operands()
+    {
+        Should.Throw<InvalidOperationException>(() => Matches("1 like 'a%'"))
+            .Message.ShouldContain("LIKE requires a character operand");
+    }
+}


### PR DESCRIPTION
## Summary
Phase 3 of the SQL plan — the WHERE evaluator, the provider's parameter story, and `ExecuteScalar`:

```sql
select Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 and Date_Visit >= '1997-01-01'
select * from dbase_03.dbf where Point_ID like 'A%' or Point_ID in ('B1', 'B2')
select Point_ID from dbase_03.dbf where Point_ID = @id
```

- **`SqlExpressionEvaluator`** (internal) interprets the bound WHERE AST per row with the agreed semantics: **three-valued NULL logic** (`NOT (col = NULL)` correctly returns no rows — the classic 2VL trap is tested), **ordinal case-sensitive string comparison ignoring trailing spaces** (matches MACHINE collation and CHAR padding, keeping scan results provably identical to the future index path), numeric widening (exact `decimal` unless `float`/`double` is involved), ISO date-string coercion against date columns, `LIKE` via cached anchored-regex translation (`%`→`.*`, `_`→`.`, everything else escaped, 100 ms timeout), and `IN`/`BETWEEN` composed with the same 3VL rules (`3 NOT IN (1, NULL)` is unknown → no match). `AND`/`OR` short-circuit on their dominant values. Type mismatches and bad date strings throw `InvalidOperationException` carrying the expression position.
- **Parameters**: `DbfDbParameter` + a fully implemented `DbfDbParameterCollection`. Named parameters match case-insensitively with or without the leading `@` (so both `AddWithValue("@id", …)` and `AddWithValue("id", …)` work — Dapper uses the latter); positional `?` placeholders bind by collection index; `DBNull` normalises to SQL NULL; `char` values compare as strings. `DbfDbCommand` exposes a typed `Parameters` property (shadowing, like `SqlCommand`) and `CreateDbParameter` now works — a prerequisite for the Dapper compatibility phase.
- **`ExecuteScalar`**: first column of the first row, `null` when no rows match.
- The filter runs inside `DbfQueryDataReader` *before* the `TOP`/`LIMIT` counter (limit applies to filtered rows) on both `Read` and `ReadAsync`. A filtered `SELECT *` routes through the query reader; a plain unfiltered `SELECT *` still returns the raw reader unchanged.

`ORDER BY` remains `NotSupportedException` — phase 4.

## Test plan
80 new tests. `SqlExpressionEvaluatorTests` exercises the coercion matrix and 3VL in isolation (literal/parameter-only expressions need no row): 58 cases covering numeric/string/boolean/date comparisons, every `LIKE`/`IN`/`BETWEEN` edge including the unknown-propagation ones, missing/`DBNull`/`char` parameters, and error positions. `DbfDbCommandWhereTests` validates end-to-end against an **in-test oracle** — every SQL result is compared with the same predicate applied in C# over a full scan of the fixture, so assertions are data-independent: equality, trailing-space equality, numeric/`BETWEEN`/`IN`/`LIKE`/date filters, compound predicates, `IS NULL` partitioning, `TOP`-after-filter, named and positional parameters, missing-parameter and type-mismatch errors at `Read()` time, async filtering, and both `ExecuteScalar` shapes. Full suite: 317 passed, 1 pre-existing skip, zero warnings on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)