### PR TITLE
Execute ORDER BY (SQL support phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ while (await reader.ReadAsync())
 }
 ```
 
-The command text supports column lists with optional aliases, a row limit, and `WHERE`
-clauses with named (`@name`) or positional (`?`) parameters:
+The command text supports column lists with optional aliases, a row limit, `WHERE`
+clauses with named (`@name`) or positional (`?`) parameters, and `ORDER BY`:
 
 ```sql
 select top 10 Point_ID as id, Date_Visit from dbase_03.dbf
@@ -194,6 +194,7 @@ select Point_ID, Max_PDOP from dbase_03.dbf limit 5
 select Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 and Date_Visit >= '1997-01-01'
 select Point_ID from dbase_03.dbf where Point_ID like 'A%' or Point_ID in ('B1', 'B2')
 select * from dbase_03.dbf where Point_ID = @id
+select top 5 Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 order by Max_PDOP desc, Point_ID
 ```
 
 ```csharp
@@ -207,7 +208,9 @@ Predicates support `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `BETWEEN`, `IN`, `LIKE
 (`%` and `_`), `IS [NOT] NULL`, `AND`/`OR`/`NOT` and parentheses. String comparisons are
 ordinal, case-sensitive and ignore trailing spaces; comparisons involving `NULL` follow
 SQL three-valued logic; date columns compare against `'yyyy-MM-dd'` or
-`'yyyy-MM-dd HH:mm:ss'` strings. `ORDER BY` is parsed but not executable yet.
+`'yyyy-MM-dd HH:mm:ss'` strings. `ORDER BY` sorts with the same comparison rules
+(multiple keys, `ASC`/`DESC`, select-list aliases allowed, nulls first ascending) using
+a stable in-memory sort of the matching rows; `TOP`/`LIMIT` applies after the sort.
 
 The connection string supports the options available in `DbfDataReaderOptions`:
 

--- a/src/DbfDataReader/DbfDbCommand.cs
+++ b/src/DbfDataReader/DbfDbCommand.cs
@@ -68,16 +68,17 @@ namespace DbfDataReader
             }
             
             var statement = SqlParser.Parse(CommandText);
-            EnsureSupported(statement);
 
             var filePath = GetFilePath(folder, statement.TableName);
 
             var options = dbfDbConnection.Options;
             var reader = new DbfDataReader(filePath, options);
 
-            // a plain unfiltered select-all needs no projection, filter or row limit,
-            // so it stays on the raw reader
-            if (statement.IsSelectAll && statement.Top == null && statement.Where == null) return reader;
+            // a plain unfiltered select-all needs no projection, filter, ordering or row
+            // limit, so it stays on the raw reader
+            if (statement.IsSelectAll && statement.Top == null && statement.Where == null &&
+                statement.OrderBy.Count == 0)
+                return reader;
 
             try
             {
@@ -107,14 +108,6 @@ namespace DbfDataReader
             }
 
             return new SqlExpressionEvaluator(statement.Where, namedParameters, positionalParameters);
-        }
-
-        // execution catches up with the parser in later phases; parse everything,
-        // run what is implemented
-        private static void EnsureSupported(SelectStatement statement)
-        {
-            if (statement.OrderBy.Count > 0)
-                throw new NotSupportedException("ORDER BY is not supported yet.");
         }
 
         private static string GetFilePath(string folder, string fileName)

--- a/src/DbfDataReader/Query/DbfQueryDataReader.cs
+++ b/src/DbfDataReader/Query/DbfQueryDataReader.cs
@@ -4,13 +4,15 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
+using System.Data.SqlTypes;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace DbfDataReader.Query
 {
     // wraps the raw table reader, exposing only the projected columns under their
-    // output names and enforcing the TOP/LIMIT row limit
+    // output names, filtering on the WHERE expression, sorting on ORDER BY (which
+    // buffers the matching rows in memory), and enforcing the TOP/LIMIT row limit
     internal sealed class DbfQueryDataReader : DbDataReader, IDbColumnSchemaGenerator
     {
         private readonly DbfDataReader _reader;
@@ -18,13 +20,19 @@ namespace DbfDataReader.Query
         private readonly IReadOnlyList<int> _ordinals; // projected ordinal -> underlying ordinal
         private readonly IReadOnlyList<string> _names; // output names (aliases applied)
         private readonly SqlExpressionEvaluator _filter; // null when there is no WHERE clause
+        private readonly IReadOnlyList<OrderByItem> _orderBy;
         private readonly int _limit; // -1 when unlimited
         private int _rowsReturned;
+
+        private List<object[]> _sortedRows; // built on first read when sorting
+        private int _sortedRowIndex;
+        private object[] _currentRow; // non-null when the current row comes from the sort buffer
 
         public DbfQueryDataReader(DbfDataReader reader, SelectStatement statement, SqlExpressionEvaluator filter)
         {
             _reader = reader;
             _filter = filter;
+            _orderBy = statement.OrderBy;
 
             var tableColumns = reader.DbfTable.Columns;
             var columns = new List<DbfColumn>();
@@ -72,6 +80,12 @@ namespace DbfDataReader.Query
 
         public override bool Read()
         {
+            if (_orderBy.Count > 0)
+            {
+                _sortedRows ??= BuildSortedRows();
+                return AdvanceSorted();
+            }
+
             if (LimitReached()) return false;
 
             while (_reader.Read())
@@ -87,6 +101,12 @@ namespace DbfDataReader.Query
 
         public override async Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
+            if (_orderBy.Count > 0)
+            {
+                _sortedRows ??= await BuildSortedRowsAsync(cancellationToken).ConfigureAwait(false);
+                return AdvanceSorted();
+            }
+
             if (LimitReached()) return false;
 
             while (await _reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -98,6 +118,97 @@ namespace DbfDataReader.Query
             }
 
             return false;
+        }
+
+        private bool AdvanceSorted()
+        {
+            if (LimitReached() || _sortedRowIndex >= _sortedRows.Count) return false;
+
+            _currentRow = _sortedRows[_sortedRowIndex];
+            _sortedRowIndex++;
+            _rowsReturned++;
+            return true;
+        }
+
+        private List<object[]> BuildSortedRows()
+        {
+            var rows = new List<object[]>();
+            while (_reader.Read())
+            {
+                if (_filter != null && !_filter.Matches(_reader)) continue;
+
+                rows.Add(SnapshotCurrentRow());
+            }
+
+            SortRows(rows);
+            return rows;
+        }
+
+        private async Task<List<object[]>> BuildSortedRowsAsync(CancellationToken cancellationToken)
+        {
+            var rows = new List<object[]>();
+            while (await _reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_filter != null && !_filter.Matches(_reader)) continue;
+
+                rows.Add(SnapshotCurrentRow());
+            }
+
+            SortRows(rows);
+            return rows;
+        }
+
+        private object[] SnapshotCurrentRow()
+        {
+            var row = new object[_reader.FieldCount];
+            for (var ordinal = 0; ordinal < row.Length; ordinal++)
+            {
+                row[ordinal] = _reader.GetValue(ordinal);
+            }
+
+            return row;
+        }
+
+        private void SortRows(List<object[]> rows)
+        {
+            if (rows.Count < 2) return;
+
+            var indices = new int[rows.Count];
+            for (var i = 0; i < indices.Length; i++) indices[i] = i;
+
+            // the original index is the final tiebreaker, making the sort stable
+            Array.Sort(indices, (x, y) =>
+            {
+                var cmp = CompareRows(rows[x], rows[y]);
+                return cmp != 0 ? cmp : x.CompareTo(y);
+            });
+
+            var sorted = new object[rows.Count][];
+            for (var i = 0; i < indices.Length; i++) sorted[i] = rows[indices[i]];
+
+            for (var i = 0; i < sorted.Length; i++) rows[i] = sorted[i];
+        }
+
+        private int CompareRows(object[] x, object[] y)
+        {
+            foreach (var item in _orderBy)
+            {
+                var cmp = CompareRowValues(x[item.Ordinal], y[item.Ordinal], item.Position);
+                if (item.Descending) cmp = -cmp;
+                if (cmp != 0) return cmp;
+            }
+
+            return 0;
+        }
+
+        // nulls sort before every value ascending (and therefore last descending)
+        private static int CompareRowValues(object x, object y, int position)
+        {
+            if (x == null && y == null) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
+
+            return SqlValueComparer.CompareValues(x, y, position);
         }
 
         private bool LimitReached()
@@ -146,7 +257,7 @@ namespace DbfDataReader.Query
 
         public override object GetValue(int ordinal)
         {
-            return _reader.GetValue(_ordinals[ordinal]);
+            return GetUnderlyingValue(_ordinals[ordinal]);
         }
 
         public override int GetValues(object[] values)
@@ -161,77 +272,101 @@ namespace DbfDataReader.Query
 
         public override bool IsDBNull(int ordinal)
         {
-            return _reader.IsDBNull(_ordinals[ordinal]);
+            return GetValue(ordinal) == null;
         }
 
         public override bool GetBoolean(int ordinal)
         {
-            return _reader.GetBoolean(_ordinals[ordinal]);
+            return GetFieldValue<bool>(ordinal);
         }
 
         public override byte GetByte(int ordinal)
         {
-            return _reader.GetByte(_ordinals[ordinal]);
+            return GetFieldValue<byte>(ordinal);
         }
 
         public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
         {
-            return _reader.GetBytes(_ordinals[ordinal], dataOffset, buffer, bufferOffset, length);
+            throw new NotImplementedException();
         }
 
         public override char GetChar(int ordinal)
         {
-            return _reader.GetChar(_ordinals[ordinal]);
+            return GetFieldValue<char>(ordinal);
         }
 
         public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
         {
-            return _reader.GetChars(_ordinals[ordinal], dataOffset, buffer, bufferOffset, length);
+            throw new NotImplementedException();
         }
 
         public override DateTime GetDateTime(int ordinal)
         {
-            return _reader.GetDateTime(_ordinals[ordinal]);
+            return GetFieldValue<DateTime>(ordinal);
         }
 
         public override decimal GetDecimal(int ordinal)
         {
-            return _reader.GetDecimal(_ordinals[ordinal]);
+            return GetFieldValue<decimal>(ordinal);
         }
 
         public override double GetDouble(int ordinal)
         {
-            return _reader.GetDouble(_ordinals[ordinal]);
+            return GetFieldValue<double>(ordinal);
         }
 
         public override float GetFloat(int ordinal)
         {
-            return _reader.GetFloat(_ordinals[ordinal]);
+            return GetFieldValue<float>(ordinal);
         }
 
         public override Guid GetGuid(int ordinal)
         {
-            return _reader.GetGuid(_ordinals[ordinal]);
+            throw new NotImplementedException();
         }
 
         public override short GetInt16(int ordinal)
         {
-            return _reader.GetInt16(_ordinals[ordinal]);
+            return GetFieldValue<short>(ordinal);
         }
 
         public override int GetInt32(int ordinal)
         {
-            return _reader.GetInt32(_ordinals[ordinal]);
+            return GetFieldValue<int>(ordinal);
         }
 
         public override long GetInt64(int ordinal)
         {
-            return _reader.GetInt64(_ordinals[ordinal]);
+            return GetFieldValue<long>(ordinal);
         }
 
         public override string GetString(int ordinal)
         {
-            return _reader.GetString(_ordinals[ordinal]);
+            var value = GetValue(ordinal);
+            if (value == null || value is string) return (string)value;
+
+            throw new InvalidCastException(
+                $"Unable to cast object of type '{value.GetType().FullName}' to type 'System.String' " +
+                $"at ordinal '{ordinal}'.");
+        }
+
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            var value = GetValue(ordinal);
+            if (value is null)
+                throw new SqlNullValueException(
+                    $"Data is Null. This method or property cannot be called on Null values. Ordinal {ordinal}");
+
+            if (value is T typed) return typed;
+
+            throw new InvalidCastException(
+                $"Unable to cast object of type '{value.GetType().FullName}' to type '{typeof(T).FullName}' " +
+                $"at ordinal '{ordinal}'.");
+        }
+
+        private object GetUnderlyingValue(int underlyingOrdinal)
+        {
+            return _currentRow != null ? _currentRow[underlyingOrdinal] : _reader.GetValue(underlyingOrdinal);
         }
 
         public override IEnumerator GetEnumerator()

--- a/src/DbfDataReader/Query/SqlBinder.cs
+++ b/src/DbfDataReader/Query/SqlBinder.cs
@@ -18,8 +18,22 @@ namespace DbfDataReader.Query
 
             foreach (var orderByItem in statement.OrderBy)
             {
-                orderByItem.Ordinal = ResolveColumn(orderByItem.ColumnName, orderByItem.Position, columns);
+                orderByItem.Ordinal = ResolveOrderByColumn(orderByItem, statement, columns);
             }
+        }
+
+        // ORDER BY may reference a select-list alias as well as a table column
+        private static int ResolveOrderByColumn(OrderByItem item, SelectStatement statement,
+            IList<DbfColumn> columns)
+        {
+            foreach (var selectColumn in statement.Columns)
+            {
+                if (selectColumn.Alias != null &&
+                    string.Equals(selectColumn.Alias, item.ColumnName, StringComparison.OrdinalIgnoreCase))
+                    return selectColumn.Ordinal;
+            }
+
+            return ResolveColumn(item.ColumnName, item.Position, columns);
         }
 
         private static void BindExpression(SqlExpression expression, IList<DbfColumn> columns)

--- a/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
+++ b/src/DbfDataReader/Query/SqlExpressionEvaluator.cs
@@ -11,13 +11,6 @@ namespace DbfDataReader.Query
     // and ignore trailing spaces, matching DBF MACHINE collation and CHAR padding.
     internal sealed class SqlExpressionEvaluator
     {
-        private static readonly string[] DateTimeFormats =
-        {
-            "yyyy-MM-dd",
-            "yyyy-MM-dd HH:mm:ss",
-            "yyyy-MM-ddTHH:mm:ss"
-        };
-
         private readonly SqlExpression _expression;
         private readonly IReadOnlyDictionary<string, object> _namedParameters;
         private readonly IReadOnlyList<object> _positionalParameters;
@@ -235,71 +228,7 @@ namespace DbfDataReader.Query
 
         private static int CompareValues(object left, object right, int position)
         {
-            if (left is string leftText && right is string rightText)
-                return string.CompareOrdinal(TrimTrailingSpaces(leftText), TrimTrailingSpaces(rightText));
-
-            if (IsNumber(left) && IsNumber(right)) return CompareNumbers(left, right);
-
-            if (left is DateTime || right is DateTime)
-                return ToDateTime(left, position).CompareTo(ToDateTime(right, position));
-
-            if (left is bool leftBool && right is bool rightBool) return leftBool.CompareTo(rightBool);
-
-            throw new InvalidOperationException(
-                $"Cannot compare values of type {left.GetType().Name} and {right.GetType().Name} " +
-                $"at position {position}.");
-        }
-
-        private static int CompareNumbers(object left, object right)
-        {
-            if (left is double || left is float || right is double || right is float)
-                return Convert.ToDouble(left, CultureInfo.InvariantCulture)
-                    .CompareTo(Convert.ToDouble(right, CultureInfo.InvariantCulture));
-
-            return Convert.ToDecimal(left, CultureInfo.InvariantCulture)
-                .CompareTo(Convert.ToDecimal(right, CultureInfo.InvariantCulture));
-        }
-
-        private static bool IsNumber(object value)
-        {
-            switch (value)
-            {
-                case byte _:
-                case sbyte _:
-                case short _:
-                case ushort _:
-                case int _:
-                case uint _:
-                case long _:
-                case ulong _:
-                case float _:
-                case double _:
-                case decimal _:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        private static DateTime ToDateTime(object value, int position)
-        {
-            switch (value)
-            {
-                case DateTime dateTime:
-                    return dateTime;
-                case string text:
-                    if (DateTime.TryParseExact(text, DateTimeFormats, CultureInfo.InvariantCulture,
-                            DateTimeStyles.None, out var parsed))
-                        return parsed;
-
-                    throw new InvalidOperationException(
-                        $"Cannot convert '{text}' to a date at position {position}; " +
-                        "use 'yyyy-MM-dd' or 'yyyy-MM-dd HH:mm:ss'.");
-                default:
-                    throw new InvalidOperationException(
-                        $"Cannot compare a date with a value of type {value.GetType().Name} " +
-                        $"at position {position}.");
-            }
+            return SqlValueComparer.CompareValues(left, right, position);
         }
 
         private Regex GetLikePattern(string pattern)
@@ -325,7 +254,7 @@ namespace DbfDataReader.Query
 
         private static string TrimTrailingSpaces(string value)
         {
-            return value.TrimEnd(' ');
+            return SqlValueComparer.TrimTrailingSpaces(value);
         }
     }
 }

--- a/src/DbfDataReader/Query/SqlValueComparer.cs
+++ b/src/DbfDataReader/Query/SqlValueComparer.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Globalization;
+
+namespace DbfDataReader.Query
+{
+    // The dialect's comparison semantics, shared by the WHERE evaluator and ORDER BY:
+    // ordinal case-sensitive string comparison ignoring trailing spaces, exact decimal
+    // comparison unless a float/double is involved, and date columns coerced from ISO
+    // strings. Callers handle nulls; both values must be non-null.
+    internal static class SqlValueComparer
+    {
+        private static readonly string[] DateTimeFormats =
+        {
+            "yyyy-MM-dd",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-ddTHH:mm:ss"
+        };
+
+        public static int CompareValues(object left, object right, int position)
+        {
+            if (left is string leftText && right is string rightText)
+                return string.CompareOrdinal(TrimTrailingSpaces(leftText), TrimTrailingSpaces(rightText));
+
+            if (IsNumber(left) && IsNumber(right)) return CompareNumbers(left, right);
+
+            if (left is DateTime || right is DateTime)
+                return ToDateTime(left, position).CompareTo(ToDateTime(right, position));
+
+            if (left is bool leftBool && right is bool rightBool) return leftBool.CompareTo(rightBool);
+
+            throw new InvalidOperationException(
+                $"Cannot compare values of type {left.GetType().Name} and {right.GetType().Name} " +
+                $"at position {position}.");
+        }
+
+        public static string TrimTrailingSpaces(string value)
+        {
+            return value.TrimEnd(' ');
+        }
+
+        private static int CompareNumbers(object left, object right)
+        {
+            if (left is double || left is float || right is double || right is float)
+                return Convert.ToDouble(left, CultureInfo.InvariantCulture)
+                    .CompareTo(Convert.ToDouble(right, CultureInfo.InvariantCulture));
+
+            return Convert.ToDecimal(left, CultureInfo.InvariantCulture)
+                .CompareTo(Convert.ToDecimal(right, CultureInfo.InvariantCulture));
+        }
+
+        private static bool IsNumber(object value)
+        {
+            switch (value)
+            {
+                case byte _:
+                case sbyte _:
+                case short _:
+                case ushort _:
+                case int _:
+                case uint _:
+                case long _:
+                case ulong _:
+                case float _:
+                case double _:
+                case decimal _:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static DateTime ToDateTime(object value, int position)
+        {
+            switch (value)
+            {
+                case DateTime dateTime:
+                    return dateTime;
+                case string text:
+                    if (DateTime.TryParseExact(text, DateTimeFormats, CultureInfo.InvariantCulture,
+                            DateTimeStyles.None, out var parsed))
+                        return parsed;
+
+                    throw new InvalidOperationException(
+                        $"Cannot convert '{text}' to a date at position {position}; " +
+                        "use 'yyyy-MM-dd' or 'yyyy-MM-dd HH:mm:ss'.");
+                default:
+                    throw new InvalidOperationException(
+                        $"Cannot compare a date with a value of type {value.GetType().Name} " +
+                        $"at position {position}.");
+            }
+        }
+    }
+}

--- a/test/DbfDataReader.Tests/DbfDbCommandOrderByTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandOrderByTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+[Collection("dbase_03")]
+public class DbfDbCommandOrderByTests
+{
+    private const string FolderPath = "../../../../fixtures";
+
+    private sealed record BaselineRow(string PointId, string Type, decimal MaxPdop, DateTime? DateVisit);
+
+    // the ordinal-ignoring-trailing-spaces comparer the dialect specifies, for LINQ oracles
+    private static readonly IComparer<string> DialectStringComparer =
+        Comparer<string>.Create((x, y) => string.CompareOrdinal(x?.TrimEnd(' '), y?.TrimEnd(' ')));
+
+    private static List<BaselineRow> ReadBaseline()
+    {
+        var rows = new List<BaselineRow>();
+
+        using var dbfTable = new DbfTable($"{FolderPath}/dbase_03.dbf");
+        var dbfRecord = new DbfRecord(dbfTable);
+
+        while (dbfTable.Read(dbfRecord))
+        {
+            rows.Add(new BaselineRow(
+                dbfRecord.GetValue<string>(0),
+                dbfRecord.GetValue<string>(1),
+                dbfRecord.GetValue<decimal>(10),
+                (DateTime?)dbfRecord.GetValue(8)));
+        }
+
+        return rows;
+    }
+
+    private static DbfDbConnection OpenConnection()
+    {
+        var connection = new DbfDbConnection();
+        connection.ConnectionString = $"Folder={FolderPath};SkipDeletedRecords=false";
+        connection.Open();
+        return connection;
+    }
+
+    private static List<string> QueryFirstColumn(string commandText)
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = commandText;
+
+        var results = new List<string>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        return results;
+    }
+
+    [Fact]
+    public void Should_order_by_a_string_column_ascending()
+    {
+        var expected = ReadBaseline().OrderBy(r => r.PointId, DialectStringComparer)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Point_ID");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_a_string_column_descending()
+    {
+        var expected = ReadBaseline().OrderByDescending(r => r.PointId, DialectStringComparer)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Point_ID desc");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_a_numeric_column()
+    {
+        var expected = ReadBaseline().OrderBy(r => r.MaxPdop).Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Max_PDOP");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_a_date_column()
+    {
+        // LINQ's OrderBy is stable and DateTime? sorts nulls first, matching the dialect
+        var expected = ReadBaseline().OrderBy(r => r.DateVisit).Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Date_Visit");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_multiple_keys_stably()
+    {
+        // Type has duplicate values, so this exercises both the second key and stability
+        var expected = ReadBaseline()
+            .OrderBy(r => r.Type, DialectStringComparer)
+            .ThenByDescending(r => r.MaxPdop)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Type, Max_PDOP desc");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_a_column_that_is_not_projected()
+    {
+        var expected = ReadBaseline().OrderBy(r => r.MaxPdop).Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID from dbase_03.dbf order by Max_PDOP asc");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_by_a_select_list_alias()
+    {
+        var expected = ReadBaseline().OrderBy(r => r.PointId, DialectStringComparer)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn("select Point_ID as id from dbase_03.dbf order by id");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_apply_where_then_order_then_top()
+    {
+        var baseline = ReadBaseline();
+        var threshold = baseline[7].MaxPdop;
+        var expected = baseline
+            .Where(r => r.MaxPdop >= threshold)
+            .OrderByDescending(r => r.MaxPdop)
+            .Take(3)
+            .Select(r => r.PointId).ToList();
+
+        var actual = QueryFirstColumn(
+            "select top 3 Point_ID from dbase_03.dbf where Max_PDOP >= " +
+            threshold.ToString(CultureInfo.InvariantCulture) + " order by Max_PDOP desc");
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_order_select_star_queries()
+    {
+        var expected = ReadBaseline().OrderByDescending(r => r.PointId, DialectStringComparer)
+            .Select(r => r.PointId).ToList();
+
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select * from dbase_03.dbf order by Point_ID desc";
+
+        var actual = new List<string>();
+        using var reader = command.ExecuteReader();
+        reader.FieldCount.ShouldBe(31);
+        while (reader.Read())
+        {
+            actual.Add(reader.GetString(0));
+        }
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task Should_order_rows_asynchronously()
+    {
+        var expected = ReadBaseline().OrderBy(r => r.MaxPdop).Select(r => r.PointId).ToList();
+
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID, Max_PDOP from dbase_03.dbf order by Max_PDOP";
+
+        var actual = new List<string>();
+        var reader = await command.ExecuteReaderAsync();
+        await using (reader.ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync())
+            {
+                actual.Add(reader.GetString(0));
+            }
+        }
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_execute_scalar_on_ordered_queries()
+    {
+        var expected = ReadBaseline().OrderByDescending(r => r.MaxPdop).First().PointId;
+
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID from dbase_03.dbf order by Max_PDOP desc";
+
+        command.ExecuteScalar().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_read_typed_values_from_the_sort_buffer()
+    {
+        using var connection = OpenConnection();
+        var command = connection.CreateCommand();
+        command.CommandText = "select Point_ID, Max_PDOP, Date_Visit from dbase_03.dbf order by Max_PDOP desc";
+
+        using var reader = command.ExecuteReader();
+        reader.Read().ShouldBeTrue();
+
+        var expected = ReadBaseline().OrderByDescending(r => r.MaxPdop).First();
+        reader.GetString(0).ShouldBe(expected.PointId);
+        reader.GetDecimal(1).ShouldBe(expected.MaxPdop);
+        reader.IsDBNull(2).ShouldBe(expected.DateVisit == null);
+        reader.GetValues(new object[3]).ShouldBe(3);
+        reader["Max_PDOP"].ShouldBe(expected.MaxPdop);
+    }
+}

--- a/test/DbfDataReader.Tests/DbfDbCommandTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandTests.cs
@@ -32,20 +32,6 @@ public class DbfDbCommandTests
         rowCount.ShouldBe(14);
     }
 
-    [Theory]
-    [InlineData("select * from dbase_03.dbf order by Point_ID", "ORDER BY")]
-    public void Should_throw_not_supported_for_parsed_but_unimplemented_features(string commandText,
-        string expectedFragment)
-    {
-        using var connection = OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = commandText;
-
-        var exception = Should.Throw<NotSupportedException>(() => command.ExecuteReader());
-
-        exception.Message.ShouldContain(expectedFragment);
-    }
-
     [Fact]
     public void Should_throw_argument_exception_for_invalid_command_text()
     {


### PR DESCRIPTION
## Summary
Phase 4 of the SQL plan — `ORDER BY` executes, completing clause execution for the agreed dialect:

```sql
select top 5 Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 order by Max_PDOP desc, Point_ID
select Point_ID as id from dbase_03.dbf order by id
```

- **`SqlValueComparer`** — the comparison core extracted from the WHERE evaluator so sorting and filtering share identical semantics by construction (ordinal case-sensitive strings ignoring trailing spaces, exact-decimal-unless-float/double numeric widening, ISO date coercion). This matters for phase 6: index-order reads must be provably interchangeable with sorted scans.
- **Sort behaviour**: multiple keys with `ASC`/`DESC`; nulls sort first ascending (last descending); stable (original row position is the final tiebreaker); `ORDER BY` can reference select-list aliases (`select Point_ID as id … order by id`) as well as table columns, including columns not in the projection.
- **Execution**: with `ORDER BY` present, `DbfQueryDataReader` buffers the WHERE-matching rows on first `Read`/`ReadAsync`, sorts once, and serves from the buffer — the only buffering operator in the engine, memory bounded by the filtered row count (documented in the README). `TOP`/`LIMIT` applies after the sort, per SQL semantics.
- **Reader internals**: value access is unified behind one accessor so every getter behaves identically whether the current row is live or buffered; typed getters are now implemented locally with the raw reader's exception semantics, and the reader **overrides `GetFieldValue<T>`** properly (previously inherited the base cast-only default) — null yields `SqlNullValueException`, wrong types yield the same `InvalidCastException` message shape as `DbfRecord`.
- The `EnsureSupported` guard is deleted — everything the parser accepts now executes.

## Test plan
12 new tests in `DbfDbCommandOrderByTests`, all validated against LINQ oracles over a full scan with a dialect-matching ordinal comparer (LINQ's `OrderBy` is stable, so stability is asserted implicitly on duplicate keys): string asc/desc, numeric, date (with nulls), multi-key with mixed directions, sort-by-unprojected-column, alias ordering, WHERE→ORDER→TOP composition, `select *` ordering, async, `ExecuteScalar` on ordered queries, and typed getters/`GetValues`/indexer served from the sort buffer. Full suite: 328 passed, 1 pre-existing skip, zero warnings on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)