### PR TITLE
Support COUNT(*) with index and status-scan fast paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ select Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 and Date_Visit >= '1997-
 select Point_ID from dbase_03.dbf where Point_ID like 'A%' or Point_ID in ('B1', 'B2')
 select * from dbase_03.dbf where Point_ID = @id
 select top 5 Point_ID from dbase_03.dbf where Max_PDOP >= 3.5 order by Max_PDOP desc, Point_ID
+select count(*) from dbase_03.dbf where Max_PDOP >= 3.5
 ```
 
 ```csharp
@@ -251,6 +252,11 @@ SQL three-valued logic; date columns compare against `'yyyy-MM-dd'` or
 `'yyyy-MM-dd HH:mm:ss'` strings. `ORDER BY` sorts with the same comparison rules
 (multiple keys, `ASC`/`DESC`, select-list aliases allowed, nulls first ascending) using
 a stable in-memory sort of the matching rows; `TOP`/`LIMIT` applies after the sort.
+`COUNT(*)` is the one supported aggregate, and it counts as cheaply as it safely can:
+without a `WHERE` it scans record status bytes only (header record counts are not
+trusted); when an index covers the `WHERE` exactly, the count comes from the index
+without reading any rows; otherwise rows are read and filtered without being projected.
+The same fast paths back `DbfQuery<T>.Count()`.
 
 When a sidecar compound index (`file.cdx`) exists next to the table, queries use it
 automatically: equality, range and `BETWEEN` predicates on indexed character, integer,

--- a/src/DbfDataReader/DbfDataReader.cs
+++ b/src/DbfDataReader/DbfDataReader.cs
@@ -44,6 +44,8 @@ namespace DbfDataReader
 
         public DbfRecord DbfRecord { get; private set; }
 
+        internal bool SkipsDeletedRecords => _options.SkipDeletedRecords;
+
         public override void Close()
         {
             try

--- a/src/DbfDataReader/DbfDbCommand.cs
+++ b/src/DbfDataReader/DbfDbCommand.cs
@@ -73,6 +73,9 @@ namespace DbfDataReader
             var filePath = GetFilePath(folder, statement.TableName);
 
             var options = dbfDbConnection.Options;
+
+            if (statement.IsCountAll) return ExecuteCount(statement, filePath, options);
+
             var reader = new DbfDataReader(filePath, options);
 
             // a plain unfiltered select-all needs no projection, filter, ordering or row
@@ -117,6 +120,18 @@ namespace DbfDataReader
             using (var table = new DbfTable(filePath, options.Encoding, options.StringTrimming,
                        options.ReadFloatsAsDecimals))
             {
+                if (statement.IsCountAll)
+                {
+                    SqlBinder.Bind(statement, table.Columns);
+                    if (statement.Where == null) return CountExecutor.StatusScanDescription;
+
+                    var (namedCount, positionalCount) = CollectParameters();
+                    var countPlan = QueryPlanner.CreatePlan(statement.Where,
+                        Array.Empty<(int Ordinal, bool Descending)>(), table, options.UseIndexes, namedCount,
+                        positionalCount);
+                    return CountExecutor.DescribeStrategy(countPlan, options.SkipDeletedRecords);
+                }
+
                 if (statement.IsSelectAll && statement.Top == null && statement.Where == null &&
                     statement.OrderBy.Count == 0)
                     return "full scan (select all)";
@@ -128,6 +143,20 @@ namespace DbfDataReader
 
                 var sortNote = statement.OrderBy.Count > 0 && !plan.SortSatisfied ? "; in-memory sort" : "";
                 return plan.Description + sortNote;
+            }
+        }
+
+        private DbDataReader ExecuteCount(SelectStatement statement, string filePath, DbfDataReaderOptions options)
+        {
+            using (var reader = new DbfDataReader(filePath, options))
+            {
+                SqlBinder.Bind(statement, reader.DbfTable.Columns);
+
+                var (namedParameters, positionalParameters) = CollectParameters();
+                var (count, _) = CountExecutor.Execute(statement, reader, options, namedParameters,
+                    positionalParameters);
+
+                return new ScalarDataReader("count", count, statement.Top == 0 ? 0 : 1);
             }
         }
 

--- a/src/DbfDataReader/DbfRecord.cs
+++ b/src/DbfDataReader/DbfRecord.cs
@@ -108,6 +108,38 @@ namespace DbfDataReader
 
         public bool Read(Stream stream)
         {
+            if (!ReadRaw(stream)) return false;
+
+            try
+            {
+                ParseValues();
+                return true;
+            }
+            catch (EndOfStreamException)
+            {
+                return false;
+            }
+        }
+
+        public async ValueTask<bool> ReadAsync(Stream stream, CancellationToken cancellationToken = default)
+        {
+            if (!await ReadRawAsync(stream, cancellationToken).ConfigureAwait(false)) return false;
+
+            try
+            {
+                ParseValues();
+                return true;
+            }
+            catch (EndOfStreamException)
+            {
+                return false;
+            }
+        }
+
+        // reads the raw record into the buffer and sets IsDeleted and RecordIndex
+        // without parsing any column values; Values keeps the previous row's contents
+        internal bool ReadRaw(Stream stream)
+        {
             var position = stream.Position;
             if (position == stream.Length) return false;
 
@@ -123,16 +155,16 @@ namespace DbfDataReader
                         return false;
                     read += r;
                 }
-
-                return ParseRecord(position);
             }
             catch (EndOfStreamException)
             {
                 return false;
             }
+
+            return ReadStatus(position);
         }
 
-        public async ValueTask<bool> ReadAsync(Stream stream, CancellationToken cancellationToken = default)
+        internal async ValueTask<bool> ReadRawAsync(Stream stream, CancellationToken cancellationToken = default)
         {
             var position = stream.Position;
             if (position == stream.Length) return false;
@@ -151,31 +183,35 @@ namespace DbfDataReader
                         return false;
                     read += r;
                 }
-
-                return ParseRecord(position);
             }
             catch (EndOfStreamException)
             {
                 return false;
             }
+
+            return ReadStatus(position);
         }
 
-        private bool ParseRecord(long position)
+        private bool ReadStatus(long position)
+        {
+            var status = _buffer[0];
+            if (status == EndOfFile) return false;
+
+            IsDeleted = status == 0x2A;
+            RecordIndex = (int) ((position - _dataOffset) / _recordLength);
+
+            return true;
+        }
+
+        private void ParseValues()
         {
             var span = new ReadOnlySpan<byte>(_buffer);
-
-            var value = span[0];
-            if (value == EndOfFile) return false;
-
-            IsDeleted = value == 0x2A;
-            RecordIndex = (int) ((position - _dataOffset) / _recordLength);
 
             foreach (var dbfValue in Values)
             {
                 var slice = span.Slice(dbfValue.Start, dbfValue.Length);
                 dbfValue.Read(slice);
             }
-            return true;
         }
 
         public object GetValue(int ordinal)

--- a/src/DbfDataReader/DbfTable.cs
+++ b/src/DbfDataReader/DbfTable.cs
@@ -200,6 +200,13 @@ namespace DbfDataReader
             return dbfRecord.Read(Stream);
         }
 
+        // advances to the next record reading only its status byte, without parsing
+        // column values
+        internal bool ReadRaw(DbfRecord dbfRecord)
+        {
+            return dbfRecord.ReadRaw(Stream);
+        }
+
         public ValueTask<bool> ReadAsync(DbfRecord dbfRecord, CancellationToken cancellationToken = default)
         {
             return dbfRecord.ReadAsync(Stream, cancellationToken);

--- a/src/DbfDataReader/Query/CountExecutor.cs
+++ b/src/DbfDataReader/Query/CountExecutor.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+
+namespace DbfDataReader.Query
+{
+    // Executes SELECT COUNT(*) without materializing rows, picking the cheapest safe
+    // strategy: when an index search covers the WHERE clause exactly, the count is the
+    // size of the search result (with per-record status checks only when deleted rows
+    // must be skipped, since index entries include them); without a WHERE clause,
+    // records are scanned reading status bytes only, skipping value parsing entirely
+    // (the header record count is not trusted - real-world files get it wrong); in all
+    // other cases the rows are read and filtered without being projected.
+    internal static class CountExecutor
+    {
+        public const string StatusScanDescription = "count via record status scan";
+
+        public static string DescribeStrategy(QueryAccessPlan plan, bool skipDeletedRecords)
+        {
+            if (plan.RecordIndexes != null && plan.CoversWhereExactly)
+            {
+                return plan.Description +
+                       (skipDeletedRecords ? " (count with record status checks)" : " (count from index only)");
+            }
+
+            return plan.Description + " (count by reading rows)";
+        }
+
+        public static (int Count, string Description) Execute(SelectStatement statement, DbfDataReader reader,
+            DbfDataReaderOptions options, IReadOnlyDictionary<string, object> namedParameters,
+            IReadOnlyList<object> positionalParameters)
+        {
+            var table = reader.DbfTable;
+            var record = reader.DbfRecord;
+
+            if (statement.Where == null)
+                return (CountByStatusScan(table, record, options.SkipDeletedRecords), StatusScanDescription);
+
+            var plan = QueryPlanner.CreatePlan(statement.Where,
+                Array.Empty<(int Ordinal, bool Descending)>(), table, options.UseIndexes, namedParameters,
+                positionalParameters);
+            var description = DescribeStrategy(plan, options.SkipDeletedRecords);
+
+            if (plan.RecordIndexes != null && plan.CoversWhereExactly)
+            {
+                if (!options.SkipDeletedRecords) return (plan.RecordIndexes.Count, description);
+
+                return (CountByStatusChecks(table, record, plan.RecordIndexes), description);
+            }
+
+            var evaluator = new SqlExpressionEvaluator(statement.Where, namedParameters, positionalParameters);
+            return (CountByReadingRows(reader, evaluator, plan), description);
+        }
+
+        private static int CountByStatusScan(DbfTable table, DbfRecord record, bool skipDeletedRecords)
+        {
+            var count = 0;
+            while (table.ReadRaw(record))
+            {
+                if (skipDeletedRecords && record.IsDeleted) continue;
+
+                count++;
+            }
+
+            return count;
+        }
+
+        private static int CountByStatusChecks(DbfTable table, DbfRecord record, IReadOnlyList<int> recordIndexes)
+        {
+            var count = 0;
+            foreach (var recordIndex in recordIndexes)
+            {
+                table.Seek(recordIndex);
+                if (!table.ReadRaw(record)) continue; // entry beyond the table
+                if (record.IsDeleted) continue;
+
+                count++;
+            }
+
+            return count;
+        }
+
+        private static int CountByReadingRows(DbfDataReader reader, SqlExpressionEvaluator evaluator,
+            QueryAccessPlan plan)
+        {
+            Func<int, object> accessor = reader.GetValue;
+            var table = reader.DbfTable;
+            var record = reader.DbfRecord;
+
+            var count = 0;
+
+            if (plan.RecordIndexes == null)
+            {
+                // reader.Read applies the skip-deleted option itself
+                while (reader.Read())
+                {
+                    if (evaluator.Matches(accessor)) count++;
+                }
+
+                return count;
+            }
+
+            foreach (var recordIndex in plan.RecordIndexes)
+            {
+                table.Seek(recordIndex);
+                if (!table.Read(record)) continue;
+                if (reader.SkipsDeletedRecords && record.IsDeleted) continue;
+                if (!evaluator.Matches(accessor)) continue;
+
+                count++;
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/DbfDataReader/Query/DbfQuery.cs
+++ b/src/DbfDataReader/Query/DbfQuery.cs
@@ -130,18 +130,69 @@ namespace DbfDataReader
         {
             var plan = Prepare();
             var record = new DbfRecord(_table);
-            Func<int, object> accessor = record.GetValue;
 
             _table.Seek(0);
 
+            var limit = _take ?? int.MaxValue;
+            var recordIndexes = plan.AccessPlan.RecordIndexes;
+
+            // an index result that is exactly the matching rows (or any index result
+            // when there is no filter) can be counted without reading row values
+            var indexCountsRows = recordIndexes != null &&
+                                  (plan.Filter == null || plan.AccessPlan.CoversWhereExactly);
+            if (indexCountsRows)
+            {
+                return _includeDeleted
+                    ? Math.Min(recordIndexes.Count, limit)
+                    : CountWithStatusChecks(recordIndexes, record, limit);
+            }
+
+            // no filter: a status-only scan skips value parsing entirely
+            if (plan.Filter == null) return CountByStatusScan(record, limit);
+
+            return CountByReadingRows(plan, record, limit);
+        }
+
+        private int CountWithStatusChecks(IReadOnlyList<int> recordIndexes, DbfRecord record, int limit)
+        {
+            var count = 0;
+            foreach (var recordIndex in recordIndexes)
+            {
+                if (count >= limit) break;
+
+                _table.Seek(recordIndex);
+                if (!_table.ReadRaw(record) || record.IsDeleted) continue;
+
+                count++;
+            }
+
+            return count;
+        }
+
+        private int CountByStatusScan(DbfRecord record, int limit)
+        {
+            var count = 0;
+            while (count < limit && _table.ReadRaw(record))
+            {
+                if (!_includeDeleted && record.IsDeleted) continue;
+
+                count++;
+            }
+
+            return count;
+        }
+
+        private int CountByReadingRows(QueryPlan plan, DbfRecord record, int limit)
+        {
+            Func<int, object> accessor = record.GetValue;
+
             var position = 0;
             var count = 0;
-            while (ReadNextRow(plan, record, ref position))
+            while (count < limit && ReadNextRow(plan, record, ref position))
             {
                 if (!Accept(record, plan, accessor)) continue;
 
                 count++;
-                if (_take != null && count >= _take.Value) break;
             }
 
             return count;

--- a/src/DbfDataReader/Query/QueryAccessPlan.cs
+++ b/src/DbfDataReader/Query/QueryAccessPlan.cs
@@ -6,10 +6,12 @@ namespace DbfDataReader.Query
     // record indexes obtained from an index search
     internal sealed class QueryAccessPlan
     {
-        private QueryAccessPlan(IReadOnlyList<int> recordIndexes, bool sortSatisfied, string description)
+        private QueryAccessPlan(IReadOnlyList<int> recordIndexes, bool sortSatisfied, bool coversWhereExactly,
+            string description)
         {
             RecordIndexes = recordIndexes;
             SortSatisfied = sortSatisfied;
+            CoversWhereExactly = coversWhereExactly;
             Description = description;
         }
 
@@ -19,16 +21,21 @@ namespace DbfDataReader.Query
         // true when the rows arrive already in ORDER BY order
         public bool SortSatisfied { get; }
 
+        // true when the record indexes are exactly the rows matching the WHERE clause,
+        // making the residual filter redundant (deleted-row handling still applies)
+        public bool CoversWhereExactly { get; }
+
         public string Description { get; }
 
         public static QueryAccessPlan FullScan(string reason)
         {
-            return new QueryAccessPlan(null, false, $"full scan ({reason})");
+            return new QueryAccessPlan(null, false, false, $"full scan ({reason})");
         }
 
-        public static QueryAccessPlan Index(IReadOnlyList<int> recordIndexes, bool sortSatisfied, string description)
+        public static QueryAccessPlan Index(IReadOnlyList<int> recordIndexes, bool sortSatisfied,
+            bool coversWhereExactly, string description)
         {
-            return new QueryAccessPlan(recordIndexes, sortSatisfied, description);
+            return new QueryAccessPlan(recordIndexes, sortSatisfied, coversWhereExactly, description);
         }
     }
 }

--- a/src/DbfDataReader/Query/QueryPlanner.cs
+++ b/src/DbfDataReader/Query/QueryPlanner.cs
@@ -164,14 +164,15 @@ namespace DbfDataReader.Query
 
         private sealed class Candidate
         {
-            public Candidate(CandidateKind kind, int ordinal, CdxIndex index, string description, byte padByte,
+            private readonly IndexTag _tag;
+
+            public Candidate(CandidateKind kind, int ordinal, IndexTag tag, string description,
                 byte[] equalityKey, Func<byte[], int> comparison, bool isExact)
             {
+                _tag = tag;
                 Kind = kind;
                 Ordinal = ordinal;
-                Index = index;
                 Description = description;
-                PadByte = padByte;
                 EqualityKey = equalityKey;
                 Comparison = comparison;
                 IsExact = isExact;
@@ -179,9 +180,9 @@ namespace DbfDataReader.Query
 
             public CandidateKind Kind { get; }
             public int Ordinal { get; }
-            public CdxIndex Index { get; }
+            public CdxIndex Index => _tag.Index;
             public string Description { get; }
-            public byte PadByte { get; }
+            public byte PadByte => _tag.PadByte;
             public byte[] EqualityKey { get; } // character equality searches
             public Func<byte[], int> Comparison { get; }
 
@@ -194,7 +195,7 @@ namespace DbfDataReader.Query
             // no key and no comparison: a provably empty result (exact by definition)
             public static Candidate Empty(CandidateKind kind, IndexTag tag, int ordinal, string description)
             {
-                return new Candidate(kind, ordinal, tag.Index, description, tag.PadByte, null, null, true);
+                return new Candidate(kind, ordinal, tag, description, null, null, true);
             }
         }
 
@@ -326,8 +327,8 @@ namespace DbfDataReader.Query
             {
                 // an equality value that cannot fit in the key is provably empty
                 return fits
-                    ? new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
-                        $"index seek (=) on tag '{tag.Name}'", tag.PadByte, target, null, true)
+                    ? new Candidate(CandidateKind.Equality, column.Ordinal, tag,
+                        $"index seek (=) on tag '{tag.Name}'", target, null, true)
                     : Candidate.Empty(CandidateKind.Equality, tag, column.Ordinal,
                         $"index seek (=) on tag '{tag.Name}'");
             }
@@ -337,8 +338,8 @@ namespace DbfDataReader.Query
             var comparison = CreateTextRangeComparison(op, target);
             if (comparison == null) return null;
 
-            return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, true);
+            return new Candidate(CandidateKind.Range, column.Ordinal, tag,
+                $"index range scan on tag '{tag.Name}'", null, comparison, true);
         }
 
         private static Func<byte[], int> CreateTextRangeComparison(SqlBinaryOperator op, byte[] target)
@@ -371,8 +372,8 @@ namespace DbfDataReader.Query
                         $"index seek (=) on tag '{tag.Name}'");
 
                 var target = CdxKeyEncoder.EncodeInteger((int)number);
-                return new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
-                    $"index seek (=) on tag '{tag.Name}'", tag.PadByte, null,
+                return new Candidate(CandidateKind.Equality, column.Ordinal, tag,
+                    $"index seek (=) on tag '{tag.Name}'", null,
                     stored => CompareBinary(stored, target), true);
             }
 
@@ -395,8 +396,8 @@ namespace DbfDataReader.Query
             var key = CdxKeyEncoder.EncodeInteger((int)bound);
             var comparison = isLowerBound ? GreaterOrEqual(key) : LessOrEqual(key);
 
-            return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, true);
+            return new Candidate(CandidateKind.Range, column.Ordinal, tag,
+                $"index range scan on tag '{tag.Name}'", null, comparison, true);
         }
 
         private static decimal AdjustIntegerBound(decimal number, SqlBinaryOperator op)
@@ -431,8 +432,8 @@ namespace DbfDataReader.Query
         {
             if (op == SqlBinaryOperator.Equal)
             {
-                return new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
-                    $"index seek (=) on tag '{tag.Name}'", tag.PadByte, null,
+                return new Candidate(CandidateKind.Equality, column.Ordinal, tag,
+                    $"index seek (=) on tag '{tag.Name}'", null,
                     stored => CompareBinary(stored, target), false);
             }
 
@@ -442,8 +443,8 @@ namespace DbfDataReader.Query
             var isLowerBound = op == SqlBinaryOperator.GreaterThanOrEqual || op == SqlBinaryOperator.GreaterThan;
             var comparison = isLowerBound ? GreaterOrEqual(target) : LessOrEqual(target);
 
-            return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, false);
+            return new Candidate(CandidateKind.Range, column.Ordinal, tag,
+                $"index range scan on tag '{tag.Name}'", null, comparison, false);
         }
 
         private static Candidate TryCreateBetweenCandidate(SqlColumnExpression column, SqlBetweenExpression between,
@@ -495,7 +496,7 @@ namespace DbfDataReader.Query
                 return CdxKeyComparer.Compare(stored, high) > 0 ? 1 : 0;
             }
 
-            return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index, description, tag.PadByte, null,
+            return new Candidate(CandidateKind.Range, column.Ordinal, tag, description, null,
                 Comparison, true);
         }
 
@@ -526,7 +527,7 @@ namespace DbfDataReader.Query
                 return CompareBinary(stored, high) > 0 ? 1 : 0;
             }
 
-            return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index, description, tag.PadByte, null,
+            return new Candidate(CandidateKind.Range, column.Ordinal, tag, description, null,
                 Comparison, isExact);
         }
 
@@ -554,8 +555,8 @@ namespace DbfDataReader.Query
                     $"index prefix scan on tag '{tag.Name}' (impossible prefix)");
             }
 
-            return new Candidate(CandidateKind.LikePrefix, column.Ordinal, tag.Index,
-                $"index prefix scan (like) on tag '{tag.Name}'", tag.PadByte, null,
+            return new Candidate(CandidateKind.LikePrefix, column.Ordinal, tag,
+                $"index prefix scan (like) on tag '{tag.Name}'", null,
                 stored => CdxKeyComparer.Compare(stored, prefixBytes), false);
         }
 

--- a/src/DbfDataReader/Query/QueryPlanner.cs
+++ b/src/DbfDataReader/Query/QueryPlanner.cs
@@ -63,13 +63,16 @@ namespace DbfDataReader.Query
 
                 if (where != null)
                 {
-                    var candidate = FindBestCandidate(where, tags, table.CurrentEncoding, namedParameters,
+                    var conjuncts = FlattenConjuncts(where).ToList();
+                    var candidate = FindBestCandidate(conjuncts, tags, table.CurrentEncoding, namedParameters,
                         positionalParameters);
                     if (candidate != null)
                     {
                         var sortSatisfied = candidate.Ordinal == orderOrdinal;
+                        var coversWhereExactly = candidate.IsExact && conjuncts.Count == 1;
                         var recordIndexes = ExecuteSearch(candidate, sortSatisfied);
-                        return QueryAccessPlan.Index(recordIndexes, sortSatisfied, candidate.Description);
+                        return QueryAccessPlan.Index(recordIndexes, sortSatisfied, coversWhereExactly,
+                            candidate.Description);
                     }
                 }
 
@@ -78,7 +81,8 @@ namespace DbfDataReader.Query
                     var entries = orderTag.Index.EnumerateEntries().ToList();
                     StabilizeDuplicateKeyRuns(entries, orderTag.Index.Header.KeyLength, orderTag.PadByte);
                     var recordIndexes = ToRecordIndexes(entries, sortSatisfied: true);
-                    return QueryAccessPlan.Index(recordIndexes, true, $"index order scan on tag '{orderTag.Name}'");
+                    return QueryAccessPlan.Index(recordIndexes, true, false,
+                        $"index order scan on tag '{orderTag.Name}'");
                 }
 
                 return QueryAccessPlan.FullScan("no matching index tag");
@@ -161,7 +165,7 @@ namespace DbfDataReader.Query
         private sealed class Candidate
         {
             public Candidate(CandidateKind kind, int ordinal, CdxIndex index, string description, byte padByte,
-                byte[] equalityKey, Func<byte[], int> comparison)
+                byte[] equalityKey, Func<byte[], int> comparison, bool isExact)
             {
                 Kind = kind;
                 Ordinal = ordinal;
@@ -170,6 +174,7 @@ namespace DbfDataReader.Query
                 PadByte = padByte;
                 EqualityKey = equalityKey;
                 Comparison = comparison;
+                IsExact = isExact;
             }
 
             public CandidateKind Kind { get; }
@@ -180,20 +185,26 @@ namespace DbfDataReader.Query
             public byte[] EqualityKey { get; } // character equality searches
             public Func<byte[], int> Comparison { get; }
 
-            // no key and no comparison: a provably empty result
+            // the search returns exactly the rows matching this conjunct, with no need
+            // for a residual filter; double and date keys are inexact because decimal
+            // bounds can collapse when converted to doubles, and LIKE always needs the
+            // pattern re-applied
+            public bool IsExact { get; }
+
+            // no key and no comparison: a provably empty result (exact by definition)
             public static Candidate Empty(CandidateKind kind, IndexTag tag, int ordinal, string description)
             {
-                return new Candidate(kind, ordinal, tag.Index, description, tag.PadByte, null, null);
+                return new Candidate(kind, ordinal, tag.Index, description, tag.PadByte, null, null, true);
             }
         }
 
-        private static Candidate FindBestCandidate(SqlExpression where, Dictionary<int, IndexTag> tags,
-            Encoding encoding, IReadOnlyDictionary<string, object> namedParameters,
-            IReadOnlyList<object> positionalParameters)
+        private static Candidate FindBestCandidate(IReadOnlyList<SqlExpression> conjuncts,
+            Dictionary<int, IndexTag> tags, Encoding encoding,
+            IReadOnlyDictionary<string, object> namedParameters, IReadOnlyList<object> positionalParameters)
         {
             Candidate best = null;
 
-            foreach (var conjunct in FlattenConjuncts(where))
+            foreach (var conjunct in conjuncts)
             {
                 var candidate = TryCreateCandidate(conjunct, tags, encoding, namedParameters, positionalParameters);
                 if (candidate == null) continue;
@@ -316,7 +327,7 @@ namespace DbfDataReader.Query
                 // an equality value that cannot fit in the key is provably empty
                 return fits
                     ? new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
-                        $"index seek (=) on tag '{tag.Name}'", tag.PadByte, target, null)
+                        $"index seek (=) on tag '{tag.Name}'", tag.PadByte, target, null, true)
                     : Candidate.Empty(CandidateKind.Equality, tag, column.Ordinal,
                         $"index seek (=) on tag '{tag.Name}'");
             }
@@ -327,7 +338,7 @@ namespace DbfDataReader.Query
             if (comparison == null) return null;
 
             return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison);
+                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, true);
         }
 
         private static Func<byte[], int> CreateTextRangeComparison(SqlBinaryOperator op, byte[] target)
@@ -362,7 +373,7 @@ namespace DbfDataReader.Query
                 var target = CdxKeyEncoder.EncodeInteger((int)number);
                 return new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
                     $"index seek (=) on tag '{tag.Name}'", tag.PadByte, null,
-                    stored => CompareBinary(stored, target));
+                    stored => CompareBinary(stored, target), true);
             }
 
             // convert the bound to the integer domain; strict operators become
@@ -385,7 +396,7 @@ namespace DbfDataReader.Query
             var comparison = isLowerBound ? GreaterOrEqual(key) : LessOrEqual(key);
 
             return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison);
+                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, true);
         }
 
         private static decimal AdjustIntegerBound(decimal number, SqlBinaryOperator op)
@@ -422,7 +433,7 @@ namespace DbfDataReader.Query
             {
                 return new Candidate(CandidateKind.Equality, column.Ordinal, tag.Index,
                     $"index seek (=) on tag '{tag.Name}'", tag.PadByte, null,
-                    stored => CompareBinary(stored, target));
+                    stored => CompareBinary(stored, target), false);
             }
 
             // strict bounds stay inclusive at the key level: converting decimals to
@@ -432,7 +443,7 @@ namespace DbfDataReader.Query
             var comparison = isLowerBound ? GreaterOrEqual(target) : LessOrEqual(target);
 
             return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index,
-                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison);
+                $"index range scan on tag '{tag.Name}'", tag.PadByte, null, comparison, false);
         }
 
         private static Candidate TryCreateBetweenCandidate(SqlColumnExpression column, SqlBetweenExpression between,
@@ -456,12 +467,12 @@ namespace DbfDataReader.Query
                 case DbfColumnType.Double:
                     return TryGetNumber(lowValue, out var lowNumber) && TryGetNumber(highValue, out var highNumber)
                         ? CreateBinaryBetweenCandidate(column, CdxKeyEncoder.EncodeDouble((double)lowNumber),
-                            CdxKeyEncoder.EncodeDouble((double)highNumber), tag, description)
+                            CdxKeyEncoder.EncodeDouble((double)highNumber), tag, description, isExact: false)
                         : null;
                 case DbfColumnType.Date:
                     return TryGetDate(lowValue, out var lowDate) && TryGetDate(highValue, out var highDate)
                         ? CreateBinaryBetweenCandidate(column, CdxKeyEncoder.EncodeDate(lowDate),
-                            CdxKeyEncoder.EncodeDate(highDate), tag, description)
+                            CdxKeyEncoder.EncodeDate(highDate), tag, description, isExact: false)
                         : null;
                 default:
                     return null;
@@ -485,7 +496,7 @@ namespace DbfDataReader.Query
             }
 
             return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index, description, tag.PadByte, null,
-                Comparison);
+                Comparison, true);
         }
 
         private static Candidate TryCreateIntegerBetweenCandidate(SqlColumnExpression column, object lowValue,
@@ -503,11 +514,11 @@ namespace DbfDataReader.Query
             var lowKey = CdxKeyEncoder.EncodeInteger((int)Math.Max(low, int.MinValue));
             var highKey = CdxKeyEncoder.EncodeInteger((int)Math.Min(high, int.MaxValue));
 
-            return CreateBinaryBetweenCandidate(column, lowKey, highKey, tag, description);
+            return CreateBinaryBetweenCandidate(column, lowKey, highKey, tag, description, isExact: true);
         }
 
         private static Candidate CreateBinaryBetweenCandidate(SqlColumnExpression column, byte[] low, byte[] high,
-            IndexTag tag, string description)
+            IndexTag tag, string description, bool isExact)
         {
             int Comparison(byte[] stored)
             {
@@ -516,7 +527,7 @@ namespace DbfDataReader.Query
             }
 
             return new Candidate(CandidateKind.Range, column.Ordinal, tag.Index, description, tag.PadByte, null,
-                Comparison);
+                Comparison, isExact);
         }
 
         private static Candidate TryCreateLikeCandidate(SqlColumnExpression column, SqlLikeExpression like,
@@ -545,7 +556,7 @@ namespace DbfDataReader.Query
 
             return new Candidate(CandidateKind.LikePrefix, column.Ordinal, tag.Index,
                 $"index prefix scan (like) on tag '{tag.Name}'", tag.PadByte, null,
-                stored => CdxKeyComparer.Compare(stored, prefixBytes));
+                stored => CdxKeyComparer.Compare(stored, prefixBytes), false);
         }
 
         private static int CompareBinary(byte[] stored, byte[] target)

--- a/src/DbfDataReader/Query/ScalarDataReader.cs
+++ b/src/DbfDataReader/Query/ScalarDataReader.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbfDataReader.Query
+{
+    // a single-row, single-column result, used for aggregate queries such as COUNT(*)
+    internal sealed class ScalarDataReader : DbDataReader, IDbColumnSchemaGenerator
+    {
+        private readonly string _name;
+        private readonly object _value;
+        private int _rowsRemaining;
+        private bool _hasCurrentRow;
+
+        public ScalarDataReader(string name, object value, int rowCount)
+        {
+            _name = name;
+            _value = value;
+            _rowsRemaining = rowCount;
+        }
+
+        public override int FieldCount => 1;
+
+        public override bool HasRows => _rowsRemaining > 0 || _hasCurrentRow;
+
+        public override bool IsClosed => false;
+
+        public override int Depth => 0;
+
+        public override int RecordsAffected => -1;
+
+        public override object this[int ordinal] => GetValue(ordinal);
+
+        public override object this[string name] => GetValue(GetOrdinal(name));
+
+        public override bool Read()
+        {
+            if (_rowsRemaining <= 0)
+            {
+                _hasCurrentRow = false;
+                return false;
+            }
+
+            _rowsRemaining--;
+            _hasCurrentRow = true;
+            return true;
+        }
+
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Read());
+        }
+
+        public override bool NextResult()
+        {
+            return false;
+        }
+
+        public override string GetName(int ordinal)
+        {
+            CheckOrdinal(ordinal);
+            return _name;
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            if (string.Equals(name, _name, StringComparison.OrdinalIgnoreCase)) return 0;
+
+            // DbDataReader.GetOrdinal is documented to throw IndexOutOfRangeException
+            // for unknown column names
+#pragma warning disable S112
+            throw new IndexOutOfRangeException();
+#pragma warning restore S112
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            CheckOrdinal(ordinal);
+            return _value.GetType();
+        }
+
+        public override string GetDataTypeName(int ordinal)
+        {
+            return GetFieldType(ordinal).Name;
+        }
+
+        public override object GetValue(int ordinal)
+        {
+            CheckOrdinal(ordinal);
+            return _value;
+        }
+
+        public override int GetValues(object[] values)
+        {
+            values[0] = _value;
+            return 1;
+        }
+
+        public override bool IsDBNull(int ordinal)
+        {
+            CheckOrdinal(ordinal);
+            return false;
+        }
+
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            var value = GetValue(ordinal);
+            if (value is T typed) return typed;
+
+            return (T)Convert.ChangeType(value, typeof(T),
+                System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public override bool GetBoolean(int ordinal) => GetFieldValue<bool>(ordinal);
+        public override byte GetByte(int ordinal) => GetFieldValue<byte>(ordinal);
+        public override char GetChar(int ordinal) => GetFieldValue<char>(ordinal);
+        public override DateTime GetDateTime(int ordinal) => GetFieldValue<DateTime>(ordinal);
+        public override decimal GetDecimal(int ordinal) => GetFieldValue<decimal>(ordinal);
+        public override double GetDouble(int ordinal) => GetFieldValue<double>(ordinal);
+        public override float GetFloat(int ordinal) => GetFieldValue<float>(ordinal);
+        public override short GetInt16(int ordinal) => GetFieldValue<short>(ordinal);
+        public override int GetInt32(int ordinal) => GetFieldValue<int>(ordinal);
+        public override long GetInt64(int ordinal) => GetFieldValue<long>(ordinal);
+        public override string GetString(int ordinal) => GetFieldValue<string>(ordinal);
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Guid GetGuid(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return new DbEnumerator(this, closeReader: false);
+        }
+
+        public ReadOnlyCollection<DbColumn> GetColumnSchema()
+        {
+            return new List<DbColumn> { new ScalarColumn(_name, _value.GetType()) }.AsReadOnly();
+        }
+
+        public override DataTable GetSchemaTable()
+        {
+            return SchemaTableBuilder.Build(GetColumnSchema());
+        }
+
+        private static void CheckOrdinal(int ordinal)
+        {
+            if (ordinal != 0) throw new ArgumentOutOfRangeException(nameof(ordinal));
+        }
+
+        private sealed class ScalarColumn : DbColumn
+        {
+            public ScalarColumn(string name, Type type)
+            {
+                ColumnName = name;
+                ColumnOrdinal = 0;
+                DataType = type;
+                DataTypeName = type.Name;
+            }
+        }
+    }
+}

--- a/src/DbfDataReader/Query/SelectStatement.cs
+++ b/src/DbfDataReader/Query/SelectStatement.cs
@@ -4,10 +4,11 @@ namespace DbfDataReader.Query
 {
     internal sealed class SelectStatement
     {
-        public SelectStatement(bool isSelectAll, IReadOnlyList<SelectColumn> columns, string tableName,
-            SqlExpression where, IReadOnlyList<OrderByItem> orderBy, int? top)
+        public SelectStatement(bool isSelectAll, bool isCountAll, IReadOnlyList<SelectColumn> columns,
+            string tableName, SqlExpression where, IReadOnlyList<OrderByItem> orderBy, int? top)
         {
             IsSelectAll = isSelectAll;
+            IsCountAll = isCountAll;
             Columns = columns;
             TableName = tableName;
             Where = where;
@@ -16,6 +17,9 @@ namespace DbfDataReader.Query
         }
 
         public bool IsSelectAll { get; }
+
+        // the statement is SELECT COUNT(*); Columns is empty
+        public bool IsCountAll { get; }
 
         // empty when IsSelectAll
         public IReadOnlyList<SelectColumn> Columns { get; }

--- a/src/DbfDataReader/Query/SqlParser.cs
+++ b/src/DbfDataReader/Query/SqlParser.cs
@@ -34,28 +34,7 @@ namespace DbfDataReader.Query
                 int? top = null;
                 if (Match(SqlTokenType.TopKeyword)) top = ParseNonNegativeInteger("TOP");
 
-                var isSelectAll = false;
-                var isCountAll = false;
-                var columns = new List<SelectColumn>();
-                if (Match(SqlTokenType.Star))
-                {
-                    isSelectAll = true;
-                }
-                else if (IsCountFunction())
-                {
-                    ParseCountAll();
-                    isCountAll = true;
-
-                    if (Current.Type == SqlTokenType.Comma)
-                        throw Error("COUNT(*) must be the only item in the select list", Current);
-                }
-                else
-                {
-                    do
-                    {
-                        columns.Add(ParseSelectColumn());
-                    } while (Match(SqlTokenType.Comma));
-                }
+                var (isSelectAll, isCountAll, columns) = ParseSelectList();
 
                 Expect(SqlTokenType.FromKeyword, "FROM");
                 var tableName = ParseName("a table name");
@@ -90,6 +69,30 @@ namespace DbfDataReader.Query
                         new SqlToken(SqlTokenType.OrderKeyword, "ORDER", orderBy[0].Position));
 
                 return new SelectStatement(isSelectAll, isCountAll, columns, tableName, where, orderBy, top);
+            }
+
+            private (bool IsSelectAll, bool IsCountAll, List<SelectColumn> Columns) ParseSelectList()
+            {
+                var columns = new List<SelectColumn>();
+
+                if (Match(SqlTokenType.Star)) return (true, false, columns);
+
+                if (IsCountFunction())
+                {
+                    ParseCountAll();
+
+                    if (Current.Type == SqlTokenType.Comma)
+                        throw Error("COUNT(*) must be the only item in the select list", Current);
+
+                    return (false, true, columns);
+                }
+
+                do
+                {
+                    columns.Add(ParseSelectColumn());
+                } while (Match(SqlTokenType.Comma));
+
+                return (false, false, columns);
             }
 
             // COUNT is not a reserved word: it only acts as a function when followed by

--- a/src/DbfDataReader/Query/SqlParser.cs
+++ b/src/DbfDataReader/Query/SqlParser.cs
@@ -35,10 +35,19 @@ namespace DbfDataReader.Query
                 if (Match(SqlTokenType.TopKeyword)) top = ParseNonNegativeInteger("TOP");
 
                 var isSelectAll = false;
+                var isCountAll = false;
                 var columns = new List<SelectColumn>();
                 if (Match(SqlTokenType.Star))
                 {
                     isSelectAll = true;
+                }
+                else if (IsCountFunction())
+                {
+                    ParseCountAll();
+                    isCountAll = true;
+
+                    if (Current.Type == SqlTokenType.Comma)
+                        throw Error("COUNT(*) must be the only item in the select list", Current);
                 }
                 else
                 {
@@ -76,7 +85,28 @@ namespace DbfDataReader.Query
                 Match(SqlTokenType.Semicolon);
                 Expect(SqlTokenType.EndOfText, "end of statement");
 
-                return new SelectStatement(isSelectAll, columns, tableName, where, orderBy, top);
+                if (isCountAll && orderBy.Count > 0)
+                    throw Error("ORDER BY cannot be used with COUNT(*)",
+                        new SqlToken(SqlTokenType.OrderKeyword, "ORDER", orderBy[0].Position));
+
+                return new SelectStatement(isSelectAll, isCountAll, columns, tableName, where, orderBy, top);
+            }
+
+            // COUNT is not a reserved word: it only acts as a function when followed by
+            // a parenthesis, so columns named "count" keep working
+            private bool IsCountFunction()
+            {
+                return Current.Type == SqlTokenType.Identifier &&
+                       string.Equals(Current.Value, "count", StringComparison.OrdinalIgnoreCase) &&
+                       _tokens[_index + 1].Type == SqlTokenType.LeftParen;
+            }
+
+            private void ParseCountAll()
+            {
+                _index++; // count
+                _index++; // (
+                Expect(SqlTokenType.Star, "'*'");
+                Expect(SqlTokenType.RightParen, "')'");
             }
 
             private SelectColumn ParseSelectColumn()

--- a/test/DbfDataReader.Tests/DapperCompatibilityTests.cs
+++ b/test/DbfDataReader.Tests/DapperCompatibilityTests.cs
@@ -67,6 +67,8 @@ public class DapperCompatibilityTests
             "select Max_PDOP from dbase_03.dbf order by Max_PDOP desc");
         maxPdop.ShouldBeGreaterThan(0m);
 
+        db.ExecuteScalar<int>("select count(*) from dbase_03.dbf").ShouldBe(14);
+
         var first = db.QueryFirstOrDefault<DapperPoint>(
             "select Point_ID, Max_PDOP, Date_Visit from dbase_03.dbf where Point_ID = 'no-such-value'");
         first.ShouldBeNull();

--- a/test/DbfDataReader.Tests/DbfDbCommandCountTests.cs
+++ b/test/DbfDataReader.Tests/DbfDbCommandCountTests.cs
@@ -1,0 +1,258 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DbfDataReader.Query;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+// COUNT(*) strategy matrix: status-only scans without a WHERE, index-only counts when
+// the index covers the WHERE exactly, status checks when deleted rows must be skipped,
+// and row reading when a residual filter is required. Counts are checked against
+// full-scan oracles throughout.
+[Collection("foxprodb")]
+public class DbfDbCommandCountTests
+{
+    private const string FixturesPath = "../../../../fixtures";
+    private const string FoxproPath = "../../../../fixtures/foxprodb";
+
+    private static DbfDbConnection OpenConnection(string folder, bool skipDeleted, bool useIndexes = true)
+    {
+        var connection = new DbfDbConnection();
+        connection.ConnectionString = $"Folder={folder};SkipDeletedRecords={skipDeleted};UseIndexes={useIndexes}";
+        connection.Open();
+        return connection;
+    }
+
+    private static (object Scalar, string Plan) CountAndExplain(string folder, string commandText,
+        bool skipDeleted = false, bool useIndexes = true)
+    {
+        using var connection = OpenConnection(folder, skipDeleted, useIndexes);
+        var command = (DbfDbCommand)connection.CreateCommand();
+        command.CommandText = commandText;
+
+        return (command.ExecuteScalar(), command.ExplainPlan());
+    }
+
+    [Fact]
+    public void Should_parse_count_star()
+    {
+        var statement = SqlParser.Parse("select count(*) from t.dbf");
+        statement.IsCountAll.ShouldBeTrue();
+        statement.Columns.ShouldBeEmpty();
+
+        SqlParser.Parse("select top 5 count ( * ) from t.dbf where a = 1").IsCountAll.ShouldBeTrue();
+
+        // COUNT is not reserved: a column named count still works
+        var columnStatement = SqlParser.Parse("select count from t.dbf");
+        columnStatement.IsCountAll.ShouldBeFalse();
+        columnStatement.Columns[0].ColumnName.ShouldBe("count");
+    }
+
+    [Theory]
+    [InlineData("select count(x) from t.dbf", "expected '*'")]
+    [InlineData("select count(*), a from t.dbf", "COUNT(*) must be the only item")]
+    [InlineData("select count(*) from t.dbf order by a", "ORDER BY cannot be used with COUNT(*)")]
+    public void Should_reject_unsupported_count_shapes(string commandText, string expectedFragment)
+    {
+        Should.Throw<SqlParseException>(() => SqlParser.Parse(commandText))
+            .Message.ShouldContain(expectedFragment);
+    }
+
+    [Fact]
+    public void Should_count_all_records_via_a_status_scan()
+    {
+        var (all, planAll) = CountAndExplain(FixturesPath, "select count(*) from dbase_03.dbf");
+        all.ShouldBe(14);
+        planAll.ShouldBe("count via record status scan");
+
+        var (active, _) = CountAndExplain(FixturesPath, "select count(*) from dbase_03.dbf", skipDeleted: true);
+        active.ShouldBe(12);
+    }
+
+    [Fact]
+    public void Should_count_filtered_rows_by_reading_them_when_no_index_applies()
+    {
+        var oracle = CountOracle(r => r.MaxPdop >= 3.5m);
+
+        var (count, plan) = CountAndExplain(FixturesPath,
+            "select count(*) from dbase_03.dbf where Max_PDOP >= 3.5");
+
+        count.ShouldBe(oracle);
+        plan.ShouldContain("(count by reading rows)");
+        plan.ShouldContain("full scan");
+    }
+
+    [Fact]
+    public void Should_count_from_the_index_alone_when_it_covers_the_where_exactly()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath, "select count(*) from calls.dbf where CONTACT_ID = 1");
+
+        count.ShouldBe(5);
+        plan.ShouldContain("index seek (=) on tag 'CONTACT_ID'");
+        plan.ShouldContain("(count from index only)");
+    }
+
+    [Fact]
+    public void Should_check_record_statuses_when_deleted_rows_are_skipped()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath, "select count(*) from calls.dbf where CONTACT_ID = 1",
+            skipDeleted: true);
+
+        count.ShouldBe(5); // calls.dbf has no deleted rows; the branch still runs
+        plan.ShouldContain("(count with record status checks)");
+    }
+
+    [Fact]
+    public void Should_count_zero_for_provably_empty_seeks()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath, "select count(*) from calls.dbf where CALL_ID = 1.5");
+
+        count.ShouldBe(0);
+        plan.ShouldContain("(count from index only)");
+    }
+
+    [Fact]
+    public void Should_read_rows_when_a_residual_filter_remains()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath,
+            "select count(*) from calls.dbf where CONTACT_ID = 1 and CALL_ID > 2");
+
+        count.ShouldBe(3); // records 3, 4, 5 of the five CONTACT_ID = 1 rows
+        plan.ShouldContain("index seek (=)");
+        plan.ShouldContain("(count by reading rows)");
+    }
+
+    [Fact]
+    public void Should_read_rows_for_inexact_index_results()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath,
+            "select count(*) from setup.dbf where KEY_NAME like 'CONT%'");
+
+        count.ShouldBe(2);
+        plan.ShouldContain("index prefix scan");
+        plan.ShouldContain("(count by reading rows)");
+    }
+
+    [Fact]
+    public void Should_count_character_equality_from_the_index_alone()
+    {
+        var (count, plan) = CountAndExplain(FoxproPath,
+            "select count(*) from setup.dbf where KEY_NAME = 'CONTACTS'");
+
+        count.ShouldBe(1);
+        plan.ShouldContain("(count from index only)");
+    }
+
+    [Fact]
+    public void Should_count_identically_with_indexes_disabled()
+    {
+        var (indexed, _) = CountAndExplain(FoxproPath, "select count(*) from calls.dbf where CONTACT_ID = 1");
+        var (scanned, plan) = CountAndExplain(FoxproPath, "select count(*) from calls.dbf where CONTACT_ID = 1",
+            useIndexes: false);
+
+        scanned.ShouldBe(indexed);
+        plan.ShouldContain("full scan (indexes disabled)");
+    }
+
+    [Fact]
+    public void Should_expose_the_count_through_a_single_row_reader()
+    {
+        using var connection = OpenConnection(FixturesPath, skipDeleted: false);
+        var command = connection.CreateCommand();
+        command.CommandText = "select count(*) from dbase_03.dbf";
+
+        using var reader = command.ExecuteReader();
+        reader.FieldCount.ShouldBe(1);
+        reader.GetName(0).ShouldBe("count");
+        reader.HasRows.ShouldBeTrue();
+
+        reader.Read().ShouldBeTrue();
+        reader.GetInt32(0).ShouldBe(14);
+        reader.GetInt64(0).ShouldBe(14L);
+        reader["count"].ShouldBe(14);
+        reader.GetFieldType(0).ShouldBe(typeof(int));
+
+        var schemaTable = reader.GetSchemaTable();
+        schemaTable.Rows.Count.ShouldBe(1);
+        schemaTable.Rows[0]["ColumnName"].ShouldBe("count");
+
+        reader.Read().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_honour_top_on_the_result_row()
+    {
+        using var connection = OpenConnection(FixturesPath, skipDeleted: false);
+
+        var command = (DbfDbCommand)connection.CreateCommand();
+        command.CommandText = "select top 0 count(*) from dbase_03.dbf";
+        using (var reader = command.ExecuteReader())
+        {
+            reader.Read().ShouldBeFalse();
+        }
+
+        command.CommandText = "select top 3 count(*) from dbase_03.dbf";
+        command.ExecuteScalar().ShouldBe(14);
+    }
+
+    [Fact]
+    public void Should_count_with_parameters()
+    {
+        using var connection = OpenConnection(FoxproPath, skipDeleted: false);
+        var command = (DbfDbCommand)connection.CreateCommand();
+        command.CommandText = "select count(*) from calls.dbf where CONTACT_ID = @id";
+        command.Parameters.AddWithValue("@id", 1);
+
+        command.ExecuteScalar().ShouldBe(5);
+        command.ExplainPlan().ShouldContain("(count from index only)");
+    }
+
+    public class CallRow
+    {
+        public long? CALL_ID { get; set; }
+        public long? CONTACT_ID { get; set; }
+    }
+
+    [Fact]
+    public void Builder_should_count_through_the_fast_paths()
+    {
+        using var dbfTable = new DbfTable($"{FoxproPath}/calls.dbf");
+
+        // no filter: status scan
+        dbfTable.Query<CallRow>().Count().ShouldBe(16);
+
+        // exact index cover, skip-deleted default: status checks
+        dbfTable.Query<CallRow>().Where(c => c.CONTACT_ID == 1).Count().ShouldBe(5);
+
+        // exact index cover, deleted included: pure index count
+        dbfTable.Query<CallRow>().Where(c => c.CONTACT_ID == 1).IncludeDeleted().Count().ShouldBe(5);
+
+        // residual filter: rows are read
+        dbfTable.Query<CallRow>().Where(c => c.CONTACT_ID == 1).Where(c => c.CALL_ID > 2).Count().ShouldBe(3);
+
+        // Take caps the count
+        dbfTable.Query<CallRow>().Where(c => c.CONTACT_ID == 1).Take(3).Count().ShouldBe(3);
+
+        // forced scans agree
+        dbfTable.Query<CallRow>().Where(c => c.CONTACT_ID == 1).WithoutIndexes().Count().ShouldBe(5);
+    }
+
+    private sealed record BaselineRow(decimal MaxPdop);
+
+    private static int CountOracle(System.Func<BaselineRow, bool> predicate)
+    {
+        var rows = new List<BaselineRow>();
+
+        using var dbfTable = new DbfTable($"{FixturesPath}/dbase_03.dbf");
+        var dbfRecord = new DbfRecord(dbfTable);
+
+        while (dbfTable.Read(dbfRecord))
+        {
+            rows.Add(new BaselineRow(dbfRecord.GetValue<decimal>(10)));
+        }
+
+        return rows.Count(predicate);
+    }
+}


### PR DESCRIPTION
Closes #293.

## Summary
`SELECT COUNT(*)` executes without materializing rows, picking the cheapest strategy the planner can prove safe — and `ExplainPlan()` tells you which one ran:

```
select count(*) from dbase_03.dbf                              → count via record status scan
select count(*) from calls.dbf where CONTACT_ID = 1           → index seek (=) on tag 'CONTACT_ID' (count from index only)
  …same with SkipDeletedRecords=true                          → … (count with record status checks)
select count(*) from calls.dbf where CONTACT_ID = 1 and CALL_ID > 2 → … (count by reading rows)
```

## The strategies
- **Status-only scan** (no WHERE): records are read but **value parsing is skipped entirely** — `DbfRecord` gains an internal `ReadRaw` (the `Read` = raw + parse split also lays groundwork for #296). The header record count is deliberately not trusted, per the long-standing decision from #283.
- **Index-only count** (zero table I/O): when the WHERE is a single conjunct served by an **exact** index candidate, the count is just the search result size. Exactness is a new planner concept (`QueryAccessPlan.CoversWhereExactly`): character and integer candidates are exact; double/date candidates are not (decimal→double conversion can collapse boundaries — the same reasoning that made their strict bounds inclusive in #298); `LIKE` always needs its pattern re-applied; provably-empty candidates are exact by definition (`where CALL_ID = 1.5` counts 0 without opening the table).
- **Index + status checks**: with `SkipDeletedRecords=true` the index result can include deleted rows, so each matched record's status byte is checked — still no value parsing.
- **Row counting**: residual filters or inexact candidates fall back to reading and filtering rows, just never projecting them.

`DbfQuery<T>.Count()` uses the same fast paths (index-only when deleted rows are included, status checks otherwise, status-only scan when filterless), honouring `Take` and `IncludeDeleted`.

## Dialect details
`COUNT` is **not a reserved word** — it acts as a function only when followed by `(`, so columns named `count` keep working (tested). `count(column)`, additional select-list items, and `ORDER BY` with `COUNT(*)` are rejected with position-carrying errors. The result is a one-row reader with an `int` column named `count`, so `ExecuteScalar` and Dapper's `ExecuteScalar<int>` compose naturally; `TOP 0` yields zero result rows per SQL semantics.

## Test plan
17 new tests: parser acceptance/rejection (including the count-as-column-name case), the full strategy matrix with `ExplainPlan` assertions and oracle-checked counts (status scan with both deleted modes, index-only, status-checks branch, provably-empty, residual, inexact `LIKE`, character equality, indexes-disabled differential), reader shape (schema, typed getters, single row), `TOP` interaction, parameterized counts, builder fast paths (filterless/exact/residual/`Take`/`IncludeDeleted`/`WithoutIndexes`), and a Dapper `ExecuteScalar<int>` line. Full suite: 433 passed, 1 pre-existing skip, zero warnings on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)