### PR TITLE
Serve descending ORDER BY from ascending index tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,9 @@ The same fast paths back `DbfQuery<T>.Count()`.
 When a sidecar compound index (`file.cdx`) exists next to the table, queries use it
 automatically: equality, range and `BETWEEN` predicates on indexed character, integer,
 numeric, double and date columns (plus prefix `LIKE` on character columns) become index
-seeks, and an `ORDER BY` matching an index tag reads in index order instead of sorting.
-This applies to SQL text and to the `Query<T>` builder alike. The planner is
+seeks, and an `ORDER BY` matching an index tag — ascending or descending — reads in
+index order instead of sorting (descending order is served by reversing the ascending
+tag). This applies to SQL text and to the `Query<T>` builder alike. The planner is
 conservative — index tags with dBASE `UNIQUE` or `FOR` filters, descending keys,
 expression keys, unsupported key types (datetime, currency), or non-ASCII character
 search values fall back to a full table scan, and the full `WHERE` clause is always

--- a/src/DbfDataReader/Query/QueryPlanner.cs
+++ b/src/DbfDataReader/Query/QueryPlanner.cs
@@ -30,7 +30,7 @@ namespace DbfDataReader.Query
         {
             if (!useIndexes) return QueryAccessPlan.FullScan("indexes disabled");
 
-            var orderOrdinal = GetSingleAscendingOrderOrdinal(orderKeys);
+            var (orderOrdinal, orderDescending) = GetSingleOrderKey(orderKeys);
             if (where == null && orderOrdinal < 0) return QueryAccessPlan.FullScan("no indexable clause");
 
             // character keys compare byte-wise; only single-byte encodings keep that
@@ -43,7 +43,8 @@ namespace DbfDataReader.Query
 
             try
             {
-                return CreatePlanCore(where, orderOrdinal, table, indexPath, namedParameters, positionalParameters);
+                return CreatePlanCore(where, orderOrdinal, orderDescending, table, indexPath, namedParameters,
+                    positionalParameters);
             }
             catch (Exception exception) when (exception is CdxException || exception is IOException ||
                                               exception is EndOfStreamException)
@@ -52,9 +53,9 @@ namespace DbfDataReader.Query
             }
         }
 
-        private static QueryAccessPlan CreatePlanCore(SqlExpression where, int orderOrdinal, DbfTable table,
-            string indexPath, IReadOnlyDictionary<string, object> namedParameters,
-            IReadOnlyList<object> positionalParameters)
+        private static QueryAccessPlan CreatePlanCore(SqlExpression where, int orderOrdinal,
+            bool orderDescending, DbfTable table, string indexPath,
+            IReadOnlyDictionary<string, object> namedParameters, IReadOnlyList<object> positionalParameters)
         {
             using (var cdxFile = new CdxFile(indexPath, table.CurrentEncoding))
             {
@@ -70,7 +71,7 @@ namespace DbfDataReader.Query
                     {
                         var sortSatisfied = candidate.Ordinal == orderOrdinal;
                         var coversWhereExactly = candidate.IsExact && conjuncts.Count == 1;
-                        var recordIndexes = ExecuteSearch(candidate, sortSatisfied);
+                        var recordIndexes = ExecuteSearch(candidate, sortSatisfied, orderDescending);
                         return QueryAccessPlan.Index(recordIndexes, sortSatisfied, coversWhereExactly,
                             candidate.Description);
                     }
@@ -79,21 +80,24 @@ namespace DbfDataReader.Query
                 if (where == null && orderOrdinal >= 0 && tags.TryGetValue(orderOrdinal, out var orderTag))
                 {
                     var entries = orderTag.Index.EnumerateEntries().ToList();
-                    StabilizeDuplicateKeyRuns(entries, orderTag.Index.Header.KeyLength, orderTag.PadByte);
+                    PrepareOrderedEntries(entries, orderTag.Index.Header.KeyLength, orderTag.PadByte,
+                        orderDescending);
                     var recordIndexes = ToRecordIndexes(entries, sortSatisfied: true);
+                    var direction = orderDescending ? " (descending)" : "";
                     return QueryAccessPlan.Index(recordIndexes, true, false,
-                        $"index order scan on tag '{orderTag.Name}'");
+                        $"index order scan{direction} on tag '{orderTag.Name}'");
                 }
 
                 return QueryAccessPlan.FullScan("no matching index tag");
             }
         }
 
-        private static int GetSingleAscendingOrderOrdinal(IReadOnlyList<(int Ordinal, bool Descending)> orderKeys)
+        private static (int Ordinal, bool Descending) GetSingleOrderKey(
+            IReadOnlyList<(int Ordinal, bool Descending)> orderKeys)
         {
-            return orderKeys != null && orderKeys.Count == 1 && !orderKeys[0].Descending
-                ? orderKeys[0].Ordinal
-                : -1;
+            return orderKeys != null && orderKeys.Count == 1
+                ? orderKeys[0]
+                : (-1, false);
         }
 
         private sealed class IndexTag
@@ -114,7 +118,9 @@ namespace DbfDataReader.Query
 
         // A tag is usable when its key expression is a plain column of a supported
         // type, ordered ascending, and carries none of the flags that make its entries
-        // a subset of the table: dBASE-style UNIQUE indexes only the first record per
+        // a subset of the table. Descending tags are skipped because their on-disk key
+        // semantics are unverified (no fixture contains one); a descending ORDER BY is
+        // served by reversing an ascending tag instead. The excluded flags: dBASE-style UNIQUE indexes only the first record per
         // key, and FOR clauses filter rows. Flag 0x04 (named CustomIndex here) is NOT
         // excluded: in Visual FoxPro files it marks primary/candidate keys, which
         // reject duplicate values instead of hiding records and therefore cover every
@@ -682,7 +688,8 @@ namespace DbfDataReader.Query
             return true;
         }
 
-        private static IReadOnlyList<int> ExecuteSearch(Candidate candidate, bool sortSatisfied)
+        private static IReadOnlyList<int> ExecuteSearch(Candidate candidate, bool sortSatisfied,
+            bool sortDescending)
         {
             List<CdxKeyEntry> entries;
 
@@ -699,8 +706,24 @@ namespace DbfDataReader.Query
                 entries = new List<CdxKeyEntry>();
             }
 
-            StabilizeDuplicateKeyRuns(entries, candidate.Index.Header.KeyLength, candidate.PadByte);
+            PrepareOrderedEntries(entries, candidate.Index.Header.KeyLength, candidate.PadByte,
+                sortSatisfied && sortDescending);
             return ToRecordIndexes(entries, sortSatisfied);
+        }
+
+        // Puts entries into the order the query needs. Ascending tags deliver keys in
+        // ascending order; a descending ORDER BY is served by reversing the list. Each
+        // run of duplicate keys is re-sorted by record index afterwards, because a
+        // stable descending sort keeps ties in their original (ascending) row order.
+        private static void PrepareOrderedEntries(List<CdxKeyEntry> entries, int keyLength, byte padByte,
+            bool descending)
+        {
+            StabilizeDuplicateKeyRuns(entries, keyLength, padByte);
+
+            if (!descending) return;
+
+            entries.Reverse();
+            StabilizeDuplicateKeyRuns(entries, keyLength, padByte);
         }
 
         // entries with equal keys carry no defined order in the index; sorting each run

--- a/test/DbfDataReader.Tests/QueryDescendingOrderTests.cs
+++ b/test/DbfDataReader.Tests/QueryDescendingOrderTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using Shouldly;
+using Xunit;
+
+namespace DbfDataReader.Tests;
+
+// Descending ORDER BY served from ascending index tags by reversing the entry list;
+// duplicate-key runs are re-sorted by record index so the result is identical to a
+// stable in-memory descending sort. Every query is compared against a forced full scan.
+[Collection("foxprodb")]
+public class QueryDescendingOrderTests
+{
+    private const string FolderPath = "../../../../fixtures/foxprodb";
+
+    private static DbfDbConnection OpenConnection(bool useIndexes)
+    {
+        var connection = new DbfDbConnection();
+        connection.ConnectionString = $"Folder={FolderPath};SkipDeletedRecords=false;UseIndexes={useIndexes}";
+        connection.Open();
+        return connection;
+    }
+
+    private static List<string> QueryRows(bool useIndexes, string commandText)
+    {
+        using var connection = OpenConnection(useIndexes);
+        var command = connection.CreateCommand();
+        command.CommandText = commandText;
+
+        var rows = new List<string>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var values = new object[reader.FieldCount];
+            reader.GetValues(values);
+            rows.Add(string.Join("|", values));
+        }
+
+        return rows;
+    }
+
+    private static string Explain(string commandText)
+    {
+        using var connection = OpenConnection(useIndexes: true);
+        var command = (DbfDbCommand)connection.CreateCommand();
+        command.CommandText = commandText;
+
+        return command.ExplainPlan();
+    }
+
+    [Fact]
+    public void Should_serve_descending_order_from_an_ascending_index()
+    {
+        var commandText = "select KEY_NAME, VALUE from setup.dbf order by KEY_NAME desc";
+
+        var plan = Explain(commandText);
+        plan.ShouldContain("index order scan (descending) on tag 'KEY_NAME'");
+        plan.ShouldNotContain("in-memory sort");
+
+        var indexed = QueryRows(useIndexes: true, commandText);
+        indexed.ShouldBe(QueryRows(useIndexes: false, commandText));
+        indexed.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Should_keep_duplicate_keys_in_stable_order_when_descending()
+    {
+        // CONTACT_ID has runs of duplicate keys; a stable descending sort keeps each
+        // run in ascending record order, and the reversed index must match exactly
+        var commandText = "select CALL_ID, CONTACT_ID from calls.dbf order by CONTACT_ID desc";
+
+        Explain(commandText).ShouldContain("index order scan (descending) on tag 'CONTACT_ID'");
+
+        QueryRows(useIndexes: true, commandText).ShouldBe(QueryRows(useIndexes: false, commandText));
+    }
+
+    [Fact]
+    public void Should_satisfy_descending_order_after_an_index_range()
+    {
+        var commandText = "select CALL_ID from calls.dbf where CALL_ID >= 5 order by CALL_ID desc";
+
+        var plan = Explain(commandText);
+        plan.ShouldContain("index range scan on tag 'CALL_ID'");
+        plan.ShouldNotContain("in-memory sort");
+
+        QueryRows(useIndexes: true, commandText).ShouldBe(QueryRows(useIndexes: false, commandText));
+    }
+
+    [Fact]
+    public void Should_satisfy_descending_order_after_an_equality_seek()
+    {
+        var commandText = "select CALL_ID from calls.dbf where CONTACT_ID = 1 order by CONTACT_ID desc";
+
+        var plan = Explain(commandText);
+        plan.ShouldContain("index seek (=) on tag 'CONTACT_ID'");
+        plan.ShouldNotContain("in-memory sort");
+
+        QueryRows(useIndexes: true, commandText).ShouldBe(QueryRows(useIndexes: false, commandText));
+    }
+
+    [Fact]
+    public void Should_apply_top_after_the_descending_index_order()
+    {
+        var commandText = "select CALL_ID from calls.dbf order by CALL_ID desc limit 3";
+
+        Explain(commandText).ShouldContain("index order scan (descending)");
+
+        var indexed = QueryRows(useIndexes: true, commandText);
+        indexed.ShouldBe(QueryRows(useIndexes: false, commandText));
+        indexed.ShouldBe(new List<string> { "16", "15", "14" });
+    }
+
+    [Fact]
+    public void Should_still_sort_in_memory_when_the_order_column_has_no_tag()
+    {
+        var commandText = "select CALL_ID from calls.dbf order by SUBJECT desc";
+
+        var plan = Explain(commandText);
+        plan.ShouldStartWith("full scan");
+        plan.ShouldContain("in-memory sort");
+
+        QueryRows(useIndexes: true, commandText).ShouldBe(QueryRows(useIndexes: false, commandText));
+    }
+
+    public class CallRow
+    {
+        public long? CALL_ID { get; set; }
+        public long? CONTACT_ID { get; set; }
+    }
+
+    [Fact]
+    public void Builder_should_serve_descending_order_from_the_index()
+    {
+        using var dbfTable = new DbfTable($"{FolderPath}/calls.dbf");
+
+        var query = dbfTable.Query<CallRow>().OrderByDescending(c => c.CONTACT_ID);
+        var plan = query.ExplainPlan();
+        plan.ShouldContain("index order scan (descending) on tag 'CONTACT_ID'");
+        plan.ShouldNotContain("in-memory sort");
+
+        var indexed = query.ToList().Select(c => $"{c.CALL_ID}|{c.CONTACT_ID}").ToList();
+        var scanned = dbfTable.Query<CallRow>().OrderByDescending(c => c.CONTACT_ID).WithoutIndexes()
+            .ToList().Select(c => $"{c.CALL_ID}|{c.CONTACT_ID}").ToList();
+
+        indexed.ShouldBe(scanned);
+    }
+
+    [Fact]
+    public void Builder_should_satisfy_descending_order_with_a_filter()
+    {
+        using var dbfTable = new DbfTable($"{FolderPath}/calls.dbf");
+
+        var indexed = dbfTable.Query<CallRow>()
+            .Where(c => c.CONTACT_ID == 1)
+            .OrderByDescending(c => c.CONTACT_ID)
+            .ToList().Select(c => c.CALL_ID).ToList();
+
+        var scanned = dbfTable.Query<CallRow>()
+            .Where(c => c.CONTACT_ID == 1)
+            .OrderByDescending(c => c.CONTACT_ID)
+            .WithoutIndexes()
+            .ToList().Select(c => c.CALL_ID).ToList();
+
+        indexed.ShouldBe(scanned);
+        indexed.Count.ShouldBe(5);
+    }
+}

--- a/test/DbfDataReader.Tests/QueryIndexTests.cs
+++ b/test/DbfDataReader.Tests/QueryIndexTests.cs
@@ -145,7 +145,8 @@ public class QueryIndexTests
     [Fact]
     public void Should_sort_in_memory_when_the_index_cannot_satisfy_the_order()
     {
-        var commandText = "select KEY_NAME from setup.dbf order by KEY_NAME desc";
+        // multi-key orderings are never index-served
+        var commandText = "select KEY_NAME from setup.dbf order by KEY_NAME desc, VALUE";
 
         Explain(commandText).ShouldStartWith("full scan");
 


### PR DESCRIPTION
Closes #294.

## Summary
`ORDER BY col DESC` is now index-served whenever the column has a usable ascending tag — previously any descending order meant a full scan plus in-memory sort:

```
select * from setup.dbf order by KEY_NAME desc                  → index order scan (descending) on tag 'KEY_NAME'
select CALL_ID from calls.dbf where CALL_ID >= 5 order by CALL_ID desc → index range scan on tag 'CALL_ID'   (no in-memory sort)
select CALL_ID from calls.dbf order by CALL_ID desc limit 3     → 16, 15, 14
```

## How
The planner reverses the ascending tag's entry list — and then **re-stabilizes each run of duplicate keys by record index**, because a stable descending sort keeps tied rows in their original *ascending* row order, while a naive reversal would flip them. The duplicate-heavy `CONTACT_ID` tag (runs of five equal keys) pins this: the reversed index order must match the forced-scan stable sort byte-for-byte, and does. Works for pure order scans, for WHERE candidates on the same column (seeks and ranges), with `TOP`/`LIMIT` applied after the order, and through `DbfQuery<T>.OrderByDescending`. Multi-key orderings and untagged columns still sort in memory, as before.

## Deliberate remainder
Tags that are themselves **DESCENDING** stay excluded from planning. No fixture anywhere contains one, and their on-disk key semantics are unverified (VFP may store complemented key bytes keeping the tree byte-ascending, or store a genuinely reversed tree) — searching them on a guess could silently miss rows, which is the one failure mode this planner never accepts. A follow-up issue tracks that remainder with the verification plan; contributing a VFP file with `INDEX ON … TAG … DESCENDING` would unblock it immediately.

## Test plan
8 new tests in `QueryDescendingOrderTests`, all differential against forced scans: descending order scans (character and integer tags), the stable-duplicate-run case, descending order satisfied after equality seeks and ranges, `LIMIT` after descending order (exact sequence asserted), untagged-column fallback, and both builder paths. The phase-6 test that pinned `DESC` to a full scan is repurposed to a genuinely unsatisfiable multi-key ordering. Full suite: 440 passed, 1 pre-existing skip, zero warnings on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)